### PR TITLE
Rollup module missing

### DIFF
--- a/.appwrite.json
+++ b/.appwrite.json
@@ -1,5 +1,5 @@
 {
-  "installCommand": "npm install --no-package-lock",
+  "installCommand": "npm install --no-package-lock --include=optional",
   "buildCommand": "npm run build",
   "outputDirectory": "dist",
   "runtime": "node20",

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -13,7 +13,7 @@ This guide explains how to deploy Mermalaid to Appwrite Sites.
 The project is configured for static site deployment with the following settings:
 
 - **Build Command**: `npm run build`
-- **Install Command**: `npm install --no-package-lock`
+- **Install Command**: `npm install --no-package-lock --include=optional`
 - **Output Directory**: `dist`
 - **Framework Adapter**: `static` (static site)
 
@@ -33,7 +33,7 @@ Configure the following in the Appwrite Console:
 
 - **Install Command**: 
   ```
-  npm install --no-package-lock
+  npm install --no-package-lock --include=optional
   ```
 
 - **Build Command**: 
@@ -181,9 +181,9 @@ If you see an error like:
 Error: Cannot find module @rollup/rollup-linux-x64-musl
 ```
 
-This is caused by npm skipping platform-specific optional dependencies when the
-lockfile was generated on a different platform. Use the `--no-package-lock`
-install command in Appwrite, or remove `package-lock.json` and reinstall.
+This is caused by npm skipping platform-specific optional dependencies in the
+Appwrite build environment. Use `npm install --no-package-lock --include=optional`
+as the install command in Appwrite, or remove `package-lock.json` and reinstall.
 
 ### Site Not Loading
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -13,7 +13,7 @@ This guide explains how to deploy Mermalaid to Appwrite Sites.
 The project is configured for static site deployment with the following settings:
 
 - **Build Command**: `npm run build`
-- **Install Command**: `npm install --no-package-lock`
+- **Install Command**: `npm install --no-package-lock --include=optional`
 - **Output Directory**: `dist`
 - **Framework Adapter**: `static` (static site)
 
@@ -33,7 +33,7 @@ Configure the following in the Appwrite Console:
 
 - **Install Command**: 
   ```
-  npm install --no-package-lock
+  npm install --no-package-lock --include=optional
   ```
 
 - **Build Command**: 
@@ -181,9 +181,9 @@ If you see an error like:
 Error: Cannot find module @rollup/rollup-linux-x64-musl
 ```
 
-This is caused by npm skipping platform-specific optional dependencies when the
-lockfile was generated on a different platform. Use the `--no-package-lock`
-install command in Appwrite, or remove `package-lock.json` and reinstall.
+This is caused by npm skipping platform-specific optional dependencies in the
+Appwrite build environment. Use `npm install --no-package-lock --include=optional`
+as the install command in Appwrite, or remove `package-lock.json` and reinstall.
 
 ### Site Not Loading
 


### PR DESCRIPTION
Update Appwrite install command to `npm install --no-package-lock` and add troubleshooting for the Rollup native module error.

The `Error: Cannot find module @rollup/rollup-linux-x64-musl` occurs during Appwrite builds because npm's handling of optional, platform-specific dependencies can fail when a `package-lock.json` generated on a different OS is used. Using `--no-package-lock` forces npm to resolve dependencies based on the build environment, mitigating this bug.

---
<p><a href="https://cursor.com/background-agent?bcId=bc-f028ecfd-c393-4cc2-b50e-fcb9c860151f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f028ecfd-c393-4cc2-b50e-fcb9c860151f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a></p>

