### PR TITLE
feat: add one-command release process and rollback guidance

### DIFF
--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -118,6 +118,34 @@ The preview server will serve the built files from the `dist` directory, allowin
 
 Automated deployment via GitHub Actions is configured and ready to use.
 
+#### One-command safe release
+
+Use the release command from a clean local `main` branch:
+
+```bash
+npm run release -- patch
+```
+
+You can also use shortcuts:
+
+```bash
+npm run release:patch
+npm run release:minor
+npm run release:major
+```
+
+The release script performs pre-checks before versioning:
+
+- Working tree must be clean
+- Current branch must be `main`
+- Local `main` must be fully synced with `origin/main`
+- Bump type must be one of `patch`, `minor`, or `major`
+
+If checks pass, it runs `npm version`, creates a `v*` tag, and pushes commit + tag (`git push origin main --follow-tags`), which triggers both workflows:
+
+- `.github/workflows/release.yml` (tag push `v*`)
+- `.github/workflows/deploy-appwrite.yml` (push to `main`)
+
 **Setup:**
 
 1. Add the following secrets to your GitHub repository (Settings → Secrets and variables → Actions):
@@ -182,6 +210,19 @@ appwrite deploy sites --siteId YOUR_SITE_ID --entrypoint dist/index.html --outpu
 ### 404 Errors on Routes
 
 - Ensure Appwrite Sites routing is configured to serve `index.html` for all routes (see `.appwrite.json`)
+
+### Release Command Fails Pre-checks
+
+- **Not on `main`**: switch branches with `git checkout main`
+- **Working tree not clean**: commit or stash changes, then re-run
+- **Behind remote**: run `git pull --ff-only origin main`
+- **Ahead of remote**: run `git push origin main`, then re-run release
+
+### Rollback Guidance
+
+- If release was already pushed, create a follow-up patch release instead of rewriting git history
+- If you must remove an accidental local tag before push, delete it locally with `git tag -d vX.Y.Z`
+- Avoid force-pushing release history on `main`
 
 ## Build Optimization
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "release": "node scripts/release.mjs",
+    "release:patch": "node scripts/release.mjs patch",
+    "release:minor": "node scripts/release.mjs minor",
+    "release:major": "node scripts/release.mjs major",
     "tauri": "tauri",
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build"

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,138 @@
+#!/usr/bin/env node
+
+import { execSync } from "node:child_process";
+
+const VALID_BUMPS = new Set(["patch", "minor", "major"]);
+
+function run(command, options = {}) {
+  return execSync(command, {
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+    ...options,
+  }).trim();
+}
+
+function fail(message, nextSteps = []) {
+  console.error(`\nRelease pre-check failed: ${message}`);
+  if (nextSteps.length > 0) {
+    console.error("\nNext steps:");
+    for (const step of nextSteps) {
+      console.error(`- ${step}`);
+    }
+  }
+  process.exit(1);
+}
+
+function assertToolExists(toolName) {
+  try {
+    run(`command -v ${toolName}`);
+  } catch {
+    fail(`Required tool not found: ${toolName}`, [
+      `Install ${toolName} and ensure it is on your PATH.`,
+    ]);
+  }
+}
+
+function parseBump() {
+  const bump = process.argv[2] ?? "patch";
+  if (!VALID_BUMPS.has(bump)) {
+    fail(`Invalid bump type "${bump}". Expected patch, minor, or major.`, [
+      "Use one of: npm run release -- patch|minor|major",
+      "Or run a shortcut: npm run release:patch|release:minor|release:major",
+    ]);
+  }
+  return bump;
+}
+
+function assertCleanWorkingTree() {
+  const status = run("git status --porcelain");
+  if (status !== "") {
+    fail("Working tree is not clean.", [
+      "Commit or stash your local changes.",
+      "Re-run the release command from a clean working tree.",
+    ]);
+  }
+}
+
+function assertOnMainBranch() {
+  const branch = run("git branch --show-current");
+  if (branch !== "main") {
+    fail(`Current branch is "${branch}", expected "main".`, [
+      "Switch branches: git checkout main",
+      "Ensure main is the intended production branch before releasing.",
+    ]);
+  }
+}
+
+function assertUpToDateWithOriginMain() {
+  try {
+    run("git fetch origin main");
+  } catch {
+    fail("Unable to fetch origin/main.", [
+      "Check your network connection and git remote access.",
+      "Verify repository permissions for origin.",
+      "Retry the release command once fetch succeeds.",
+    ]);
+  }
+
+  let counts = "";
+  try {
+    counts = run("git rev-list --left-right --count origin/main...main");
+  } catch {
+    fail("Unable to compare local main with origin/main.", [
+      "Ensure origin/main exists and your repository state is valid.",
+      "Run: git fetch origin main",
+      "Retry the release command once comparison succeeds.",
+    ]);
+  }
+
+  const [behindRaw, aheadRaw] = counts.split(/\s+/);
+  const behind = Number.parseInt(behindRaw ?? "0", 10);
+  const ahead = Number.parseInt(aheadRaw ?? "0", 10);
+
+  if (behind > 0) {
+    fail(`Local main is behind origin/main by ${behind} commit(s).`, [
+      "Pull latest changes: git pull --ff-only origin main",
+      "Resolve any sync issues, then re-run release.",
+    ]);
+  }
+
+  if (ahead > 0) {
+    fail(`Local main is ahead of origin/main by ${ahead} commit(s).`, [
+      "Push outstanding commits first: git push origin main",
+      "Re-run release once local and remote main match.",
+    ]);
+  }
+}
+
+function release(bump) {
+  console.log(`\nStarting release (${bump})...`);
+  const newVersion = run(`npm version ${bump}`);
+  console.log(`Version bumped and tag created: ${newVersion}`);
+  try {
+    run("git push origin main --follow-tags", { stdio: "inherit" });
+  } catch {
+    fail("Failed to push release commit/tag to origin.", [
+      "Check your network connection and git remote access.",
+      "Confirm you have permission to push to origin/main.",
+      "Resolve push errors, then re-run release.",
+    ]);
+  }
+  console.log("\nRelease push completed.");
+  console.log("GitHub Actions should now trigger:");
+  console.log("- Release (tag push: v*)");
+  console.log("- Deploy to Appwrite Sites (push to main)");
+}
+
+function main() {
+  assertToolExists("git");
+  assertToolExists("npm");
+
+  const bump = parseBump();
+  assertCleanWorkingTree();
+  assertOnMainBranch();
+  assertUpToDateWithOriginMain();
+  release(bump);
+}
+
+main();


### PR DESCRIPTION
- Introduced a new release command in `package.json` for streamlined versioning.
- Added detailed instructions in `DEPLOYMENT.md` for executing safe releases and handling pre-checks.
- Included rollback guidance to manage accidental releases and local tag deletions.