### PR TITLE
Add test coverage (unit, integration, E2E) and CI workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: Test
+
+on:
+  push:
+    branches: [main, master]
+  pull_request:
+
+jobs:
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - run: npm run test
+
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install chromium --with-deps
+      - run: npm run test:e2e
+        env:
+          CI: true

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 logs
 *.log
 .env
+
+# Playwright
+/playwright-report/
+/test-results/
+/blob-report/
+/playwright/.cache/
 .env.local
 .env.*.local
 *.app

--- a/e2e/editor-toolbar.spec.ts
+++ b/e2e/editor-toolbar.spec.ts
@@ -1,0 +1,63 @@
+import { expect, test } from '@playwright/test'
+
+/**
+ * README: keyboard shortcuts (⌘/Ctrl+N), Save, SVG/ASCII export, Copy Code, themes.
+ * Runs against web build only (no Tauri dialogs).
+ */
+test.describe('Editor toolbar (web)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/editor')
+    await expect(page.locator('.preview-svg-host')).toBeVisible({ timeout: 30_000 })
+  })
+
+  test('Copy Code puts fenced mermaid in the clipboard', async ({ page }) => {
+    await page.getByRole('button', { name: 'Copy Code' }).click()
+    await expect(page.getByText('Code copied to clipboard')).toBeVisible()
+
+    const clip = await page.evaluate(() => navigator.clipboard.readText())
+    expect(clip.trimStart()).toMatch(/^```mermaid\s*\n/)
+    expect(clip).toContain('graph TD')
+    expect(clip.trimEnd()).toMatch(/```\s*$/)
+  })
+
+  test('Save downloads diagram.mmd', async ({ page }) => {
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: 'Save' }).click(),
+    ])
+    expect(download.suggestedFilename()).toBe('diagram.mmd')
+    await expect(page.getByText('Saved diagram.mmd')).toBeVisible()
+  })
+
+  test('Export SVG downloads diagram.svg', async ({ page }) => {
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: 'Export SVG' }).click(),
+    ])
+    expect(download.suggestedFilename()).toBe('diagram.svg')
+    await expect(page.getByText('Exported diagram.svg')).toBeVisible()
+  })
+
+  test('Export ASCII downloads diagram.txt', async ({ page }) => {
+    const [download] = await Promise.all([
+      page.waitForEvent('download'),
+      page.getByRole('button', { name: 'Export ASCII' }).click(),
+    ])
+    expect(download.suggestedFilename()).toBe('diagram.txt')
+    await expect(page.getByText('Exported diagram.txt')).toBeVisible()
+  })
+
+  test('theme select toggles app dark class for github-dark', async ({ page }) => {
+    await page.locator('select.toolbar-select').selectOption('github-dark')
+    await expect(page.locator('.app.app-theme-dark')).toBeVisible()
+    await page.locator('select.toolbar-select').selectOption('github-light')
+    await expect(page.locator('.app.app-theme-light')).toBeVisible()
+  })
+
+  test('Ctrl+N confirms and keeps a valid preview', async ({ page }) => {
+    page.once('dialog', (d) => d.accept())
+    await page.keyboard.press('Control+KeyN')
+    await expect(page.locator('.error-indicator')).toHaveCount(0)
+    await expect(page.locator('.preview-svg-host')).toBeVisible({ timeout: 30_000 })
+  })
+})

--- a/e2e/editor-toolbar.spec.ts
+++ b/e2e/editor-toolbar.spec.ts
@@ -56,7 +56,7 @@ test.describe('Editor toolbar (web)', () => {
 
   test('Ctrl+N confirms and keeps a valid preview', async ({ page }) => {
     page.once('dialog', (d) => d.accept())
-    await page.keyboard.press('Control+KeyN')
+    await page.keyboard.press('Control+N')
     await expect(page.locator('.error-indicator')).toHaveCount(0)
     await expect(page.locator('.preview-svg-host')).toBeVisible({ timeout: 30_000 })
   })

--- a/e2e/landing-editor.spec.ts
+++ b/e2e/landing-editor.spec.ts
@@ -1,0 +1,19 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('Landing and editor', () => {
+  test('landing exposes Open Editor; /editor loads toolbar and panes', async ({ page }) => {
+    await page.goto('/')
+    await expect(page.getByRole('link', { name: 'Open Editor' })).toBeVisible()
+
+    await page.goto('/editor')
+    await expect(page.locator('.toolbar')).toBeVisible()
+    await expect(page.locator('.editor-container')).toBeVisible()
+    await expect(page.locator('.preview-container')).toBeVisible()
+  })
+
+  test('default flowchart preview renders without a global error banner', async ({ page }) => {
+    await page.goto('/editor')
+    await expect(page.locator('.error-indicator')).toHaveCount(0)
+    await expect(page.locator('.preview-svg-host')).toBeVisible({ timeout: 30_000 })
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,15 +26,35 @@
         "yaml": "^2.8.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.56.1",
         "@tauri-apps/cli": "^2.9.2",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@types/html2canvas": "^0.5.35",
         "@types/node": "^24.9.2",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@vitejs/plugin-react": "^5.1.0",
+        "jsdom": "^27.2.0",
         "typescript": "^5.2.2",
-        "vite": "^7.2.1"
+        "vite": "^7.2.1",
+        "vitest": "^4.0.18"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@antfu/install-pkg": {
       "version": "1.1.0",
@@ -48,6 +68,61 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.2.tgz",
+      "integrity": "sha512-NfBUvBaYgKIuq6E/RBLY1m0IohzNHAYyaJGuTK79Z23uNwmz2jl1mPsC5ZxCCxylinKhT1Amn5oNTlx1wN8cQg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.0.0",
+        "@csstools/css-color-parser": "^4.0.1",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.5"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -283,6 +358,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -375,6 +460,146 @@
       "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
       "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
       "license": "Apache-2.0"
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.2.tgz",
+      "integrity": "sha512-5GkLzz4prTIpoyeUiIu3iV6CSG3Plo7xRVOFPKI7FVEJ3mZ0A8SwK0XU3Gl7xAkiQ+mDyam+NNp875/C5y+jSA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "peerDependencies": {
+        "css-tree": "^3.2.1"
+      },
+      "peerDependenciesMeta": {
+        "css-tree": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      }
     },
     "node_modules/@dagrejs/dagre": {
       "version": "2.0.4",
@@ -833,6 +1058,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+      "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@iconify/types": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
@@ -930,6 +1173,22 @@
         "monaco-editor": ">= 0.25.0 < 1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1289,6 +1548,13 @@
         "win32"
       ]
     },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@tauri-apps/api": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/@tauri-apps/api/-/api-2.9.0.tgz",
@@ -1543,6 +1809,104 @@
         "@tauri-apps/api": "^2.8.0"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1586,6 +1950,17 @@
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3": {
@@ -1841,6 +2216,13 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1957,6 +2339,119 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/@xyflow/react": {
       "version": "12.9.2",
       "resolved": "https://registry.npmjs.org/@xyflow/react/-/react-12.9.2.tgz",
@@ -1999,6 +2494,61 @@
       },
       "engines": {
         "node": ">=0.4.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/base64-arraybuffer": {
@@ -2048,6 +2598,16 @@
       "license": "MIT",
       "engines": {
         "node": ">17.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/browserslist": {
@@ -2104,6 +2664,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chevrotain": {
       "version": "11.1.2",
@@ -2188,6 +2758,53 @@
       "license": "MIT",
       "dependencies": {
         "utrie": "^1.0.2"
+      }
+    },
+    "node_modules/css-tree": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+      "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.27.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.7",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.7.tgz",
+      "integrity": "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -2696,6 +3313,30 @@
         "lodash-es": "^4.17.21"
       }
     },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/dayjs": {
       "version": "1.11.20",
       "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
@@ -2720,6 +3361,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/delaunator": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
@@ -2728,6 +3376,24 @@
       "dependencies": {
         "robust-predicates": "^3.0.2"
       }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dompurify": {
       "version": "3.3.2",
@@ -2747,6 +3413,26 @@
       "integrity": "sha512-sM6HAN2LyK82IyPBpznDRqlTQAtuSaO+ShzFiWTvoMJLHyZ+Y39r8VMfHzwbU8MVBzQ4Wdn85+wlZl2TLGIlwg==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/esbuild": {
       "version": "0.27.3",
@@ -2800,6 +3486,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -2849,6 +3555,19 @@
       "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
       "license": "MIT"
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html2canvas": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/html2canvas/-/html2canvas-1.4.1.tgz",
@@ -2860,6 +3579,34 @@
       },
       "engines": {
         "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -2874,6 +3621,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -2883,11 +3640,58 @@
         "node": ">=12"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
     },
     "node_modules/jsesc": {
       "version": "3.1.0",
@@ -2996,6 +3800,27 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/marked": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
@@ -3008,6 +3833,13 @@
       "engines": {
         "node": ">= 18"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+      "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/mermaid": {
       "version": "11.13.0",
@@ -3048,6 +3880,16 @@
       },
       "engines": {
         "node": ">= 20"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/mlly": {
@@ -3106,11 +3948,35 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/package-manager-detector": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
       "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
       "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
     },
     "node_modules/path-data-parser": {
       "version": "0.1.0",
@@ -3153,6 +4019,53 @@
         "confbox": "^0.1.8",
         "mlly": "^1.7.4",
         "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/points-on-curve": {
@@ -3200,6 +4113,32 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
@@ -3224,6 +4163,14 @@
       "peerDependencies": {
         "react": "^18.3.1"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -3284,6 +4231,30 @@
       "peerDependencies": {
         "react": "*",
         "react-dom": "*"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/robust-predicates": {
@@ -3361,6 +4332,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
@@ -3386,6 +4370,13 @@
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
       "license": "MIT"
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3396,16 +4387,50 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
       "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
       "license": "MIT"
     },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stylis": {
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
       "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/text-segmentation": {
@@ -3416,6 +4441,13 @@
       "dependencies": {
         "utrie": "^1.0.2"
       }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tinyexec": {
       "version": "1.0.4",
@@ -3441,6 +4473,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+      "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.28"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.28",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+      "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+      "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-dedent": {
@@ -3616,6 +4704,88 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
     "node_modules/vscode-jsonrpc": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
@@ -3663,6 +4833,109 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
       "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/yallist": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,10 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
     "release": "node scripts/release.mjs",
     "release:patch": "node scripts/release.mjs patch",
     "release:minor": "node scripts/release.mjs minor",
@@ -36,13 +40,19 @@
     "yaml": "^2.8.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.56.1",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@tauri-apps/cli": "^2.9.2",
     "@types/html2canvas": "^0.5.35",
     "@types/node": "^24.9.2",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@vitejs/plugin-react": "^5.1.0",
+    "jsdom": "^27.2.0",
     "typescript": "^5.2.2",
-    "vite": "^7.2.1"
+    "vite": "^7.2.1",
+    "vitest": "^4.0.18"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig, devices } from '@playwright/test'
+
+const port = Number(process.env.PORT || 5173)
+const baseURL = `http://127.0.0.1:${port}`
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'list',
+  use: {
+    baseURL,
+    trace: 'on-first-retry',
+    // Copy Code / clipboard E2E
+    permissions: ['clipboard-read', 'clipboard-write'],
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  webServer: {
+    // Avoid `host: true` from vite.config (networkInterfaces); keep E2E stable in CI/sandbox.
+    command: `npm run dev -- --host 127.0.0.1 --port ${port} --strictPort`,
+    url: baseURL,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1946,7 +1946,7 @@ dependencies = [
 
 [[package]]
 name = "mermalaid"
-version = "1.5.6"
+version = "1.5.7"
 dependencies = [
  "serde",
  "serde_json",

--- a/src/App.integration.test.tsx
+++ b/src/App.integration.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import App from './App'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => false,
+  invoke: async () => [] as string[],
+}))
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: async () => () => {},
+}))
+
+vi.mock('./nativeAppMenu', () => ({
+  initNativeAppMenu: async () => {},
+  setNativeMenuHandlerSource: () => {},
+}))
+
+vi.mock('./hooks/useUpdateCheck', () => ({
+  useUpdateCheck: () => ({ update: null, dismiss: () => {} }),
+}))
+
+vi.mock('@monaco-editor/react', () => ({
+  __esModule: true,
+  default: function MonacoEditorMock() {
+    return <div data-testid="monaco-editor-mock" />
+  },
+  loader: {
+    init: async () => ({
+      languages: {
+        register: () => {},
+        setMonarchTokensProvider: () => {},
+        setLanguageConfiguration: () => {},
+      },
+    }),
+  },
+}))
+
+describe('App (web)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders landing with editor entry point on /', async () => {
+    render(
+      <MemoryRouter initialEntries={['/']}>
+        <App />
+      </MemoryRouter>,
+    )
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: /open editor/i })).toBeInTheDocument()
+    })
+  })
+
+  it('renders editor shell on /editor', async () => {
+    const { container } = render(
+      <MemoryRouter initialEntries={['/editor']}>
+        <App />
+      </MemoryRouter>,
+    )
+    await waitFor(() => {
+      expect(container.querySelector('.toolbar')).toBeTruthy()
+      expect(container.querySelector('.editor-container')).toBeTruthy()
+      expect(container.querySelector('.preview-container')).toBeTruthy()
+    })
+  })
+})

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import Toolbar, { type ToolbarRef } from './components/Toolbar'
 import LandingPage from './components/LandingPage'
 import UpdateAvailableBanner from './components/UpdateAvailableBanner'
 import type { LatestReleaseInfo } from './utils/githubRelease'
+import { isDiagramImportFileName } from './utils/diagramImportFiles'
 import { extractMermaidCode, extractAllMermaidBlocks } from './utils/mermaidCodeBlock'
 import { getAppThemeCssVars, isAppThemeDark } from './utils/mermaidThemes'
 import { initNativeAppMenu, setNativeMenuHandlerSource } from './nativeAppMenu'
@@ -134,7 +135,7 @@ function EditorView({ pendingRelease, onDismissPendingRelease }: ReleaseBannerRo
   const handleDrop = (e: React.DragEvent) => {
     e.preventDefault()
     const file = e.dataTransfer.files[0]
-    if (!file || (!file.name.endsWith('.mmd') && !file.name.endsWith('.txt') && !file.name.endsWith('.md'))) {
+    if (!file || !isDiagramImportFileName(file.name)) {
       return
     }
 

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react'
 import EditorComponent, { loader } from '@monaco-editor/react'
 import { useTheme } from '../hooks/useTheme'
 import { isAppThemeDark } from '../utils/mermaidThemes'
+import { MERMLAID_EDITOR_AUTOSAVE_DEBOUNCE_MS } from '../constants/mermalaidTiming'
 import type { MermaidBlock } from '../utils/mermaidCodeBlock'
 import './Editor.css'
 
@@ -154,7 +155,7 @@ export default function Editor({
     }
     debounceTimer.current = setTimeout(() => {
       localStorage.setItem('mermalaid-draft', code)
-    }, 500)
+    }, MERMLAID_EDITOR_AUTOSAVE_DEBOUNCE_MS)
     return () => {
       if (debounceTimer.current) {
         clearTimeout(debounceTimer.current)

--- a/src/components/Preview.css
+++ b/src/components/Preview.css
@@ -89,6 +89,26 @@
   height: auto;
 }
 
+.preview-svg-host .preview-about-mermalaid {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 12px 16px;
+  max-width: min(100%, 42rem);
+  max-height: 100%;
+  text-align: left;
+  align-self: center;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--app-fg);
+  background: var(--app-surface);
+  border: 1px solid var(--app-border);
+  border-radius: 6px;
+  overflow: auto;
+}
+
 .empty-preview {
   color: var(--app-muted);
   font-size: 14px;

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -18,6 +18,10 @@ import {
   parseMermaidConfigForOfficialRenderer,
   replaceDiagramInBlock,
 } from '../utils/mermaidYamlConfig'
+import {
+  buildMermalaidAboutPreviewHtml,
+  isMermaidAboutKeywordOnly,
+} from '../utils/mermalaidInfoText'
 import { renderOfficialMermaidPreview } from '../utils/officialMermaidPreview'
 import VisualEditor from './VisualEditor'
 import './Preview.css'
@@ -232,6 +236,26 @@ export default function Preview({
       const currentId = ++renderIdRef.current
       const container = previewRef.current
 
+      const applyMermalaidAboutPanel = async () => {
+        try {
+          const html = await buildMermalaidAboutPreviewHtml()
+          if (renderIdRef.current === currentId && container) {
+            container.innerHTML = html
+            setError(null)
+            setDiagramReady(true)
+            setPreviewFitTick((t) => t + 1)
+          }
+        } catch (err) {
+          const errorMsg =
+            err instanceof Error ? err.message : 'Could not load Mermalaid info'
+          setError(errorMsg)
+          if (renderIdRef.current === currentId && container) {
+            container.innerHTML = `<div class="error-preview">${errorMsg}</div>`
+            setDiagramReady(false)
+          }
+        }
+      }
+
       if (isEditMode && canEdit) {
         return
       }
@@ -242,6 +266,11 @@ export default function Preview({
           setError(null)
           setDiagramReady(false)
         }
+        return
+      }
+
+      if (isMermaidAboutKeywordOnly(diagramCode)) {
+        await applyMermalaidAboutPanel()
         return
       }
 
@@ -272,6 +301,10 @@ export default function Preview({
             }
           } catch {
             // Last-resort legacy renderer fallback for pre-existing diagrams.
+            if (isMermaidAboutKeywordOnly(normalizedForCompat)) {
+              await applyMermalaidAboutPanel()
+              return
+            }
             const themeOptions = yamlConfig
               ? mapMermaidConfigToThemeOptions(yamlConfig)
               : previewThemeOptions

--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -23,6 +23,7 @@ import {
   isMermaidAboutKeywordOnly,
 } from '../utils/mermalaidInfoText'
 import { renderOfficialMermaidPreview } from '../utils/officialMermaidPreview'
+import { MERMLAID_PREVIEW_DEBOUNCE_MS } from '../constants/mermalaidTiming'
 import VisualEditor from './VisualEditor'
 import './Preview.css'
 
@@ -327,7 +328,7 @@ export default function Preview({
           setDiagramReady(false)
         }
       }
-    }, 500)
+    }, MERMLAID_PREVIEW_DEBOUNCE_MS)
 
     return () => clearTimeout(timer)
   }, [

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -28,7 +28,11 @@ import {
   mapMermaidConfigToThemeOptions,
 } from '../utils/mermaidYamlConfig'
 import { renderOfficialMermaidPreview } from '../utils/officialMermaidPreview'
-import packageJson from '../../package.json'
+import {
+  buildMermalaidAboutPreviewHtml,
+  buildMermalaidInfoText,
+  isMermaidAboutKeywordOnly,
+} from '../utils/mermalaidInfoText'
 import Settings from './Settings'
 import { rebuildNativeAppMenu } from '../nativeAppMenu'
 import { addRecentFile, recentFileLabel, removeRecentFile } from '../utils/recentFiles'
@@ -56,10 +60,6 @@ https://github.com/highvoltag3/mermalaid/blob/main/LICENSE
 
 Full license text:
 https://creativecommons.org/licenses/by-nc-sa/4.0/`
-
-const ENGINE_VERSION_INFO_TEXT = `Mermalaid ${packageJson.version}
-Official Mermaid engine: ${packageJson.dependencies?.mermaid ?? 'unknown'}
-Visual editor/export engine: ${packageJson.dependencies?.['beautiful-mermaid'] ?? 'unknown'}`
 
 interface ToolbarProps {
   code: string
@@ -295,15 +295,16 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
 
   const handleEngineVersionInfo = () => {
     const show = async () => {
+      const text = await buildMermalaidInfoText()
       if (isTauri()) {
-        await message(ENGINE_VERSION_INFO_TEXT, { title: 'Mermalaid Engine Version', kind: 'info' })
+        await message(text, { title: 'About Mermalaid', kind: 'info' })
       } else {
-        window.alert(ENGINE_VERSION_INFO_TEXT)
+        window.alert(text)
       }
     }
     void show().catch((err) => {
-      console.error('Failed to show engine version info:', err)
-      showToast('Failed to show engine version info.', 'error')
+      console.error('Failed to show Mermalaid info:', err)
+      showToast('Failed to show Mermalaid info.', 'error')
     })
   }
 
@@ -385,6 +386,25 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
       showToast('No diagram to export', 'error')
       return
     }
+    if (isMermaidAboutKeywordOnly(diagramCode)) {
+      void (async () => {
+        try {
+          const text = await buildMermalaidInfoText()
+          const blob = new Blob([text], { type: 'text/plain' })
+          const url = URL.createObjectURL(blob)
+          const a = document.createElement('a')
+          a.href = url
+          a.download = 'diagram.txt'
+          a.click()
+          URL.revokeObjectURL(url)
+          showToast('Exported diagram.txt')
+        } catch (err) {
+          console.error('ASCII export error:', err)
+          showToast('Failed to export Mermalaid info.', 'error')
+        }
+      })()
+      return
+    }
     try {
       const ascii = renderMermaidAscii(
         normalizeMermaidForBeautifulMermaid(diagramCode),
@@ -431,6 +451,10 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
         : defaultThemeOptions
       const normalizedForCompat = normalizeMermaidForBeautifulMermaid(diagramCode)
       try {
+        if (isMermaidAboutKeywordOnly(diagramCode)) {
+          svgs.push(await buildMermalaidAboutPreviewHtml())
+          continue
+        }
         let svg: string
         try {
           svg = await renderOfficialMermaidPreview(
@@ -472,7 +496,8 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
 <style>body{background:${bg};color:${fg};font-family:system-ui;padding:2rem}
 .diagram{margin:2rem 0;padding:1rem;border:1px solid ${isDark ? '#444' : '#ddd'};border-radius:8px}
 .diagram h2{margin:0 0 1rem;font-size:1rem}
-.diagram svg{max-width:100%;height:auto}</style></head><body>
+.diagram svg{max-width:100%;height:auto}
+.preview-about-mermalaid{white-space:pre-wrap;word-break:break-word;font-family:ui-monospace,Menlo,Monaco,Consolas,monospace;font-size:13px;line-height:1.45;margin:0}</style></head><body>
 <h1>Mermaid Diagrams (${svgs.length})</h1>
 ${svgs.map((svg, i) => `<div class="diagram"><h2>Diagram ${i + 1}</h2>${svg}</div>`).join('\n')}
 </body></html>`

--- a/src/constants/mermalaidTiming.test.ts
+++ b/src/constants/mermalaidTiming.test.ts
@@ -1,0 +1,13 @@
+/**
+ * README § Editor Features — Live preview debounce (500ms) & auto-save to localStorage (500ms).
+ */
+import { describe, expect, it } from 'vitest'
+import { MERMLAID_EDITOR_AUTOSAVE_DEBOUNCE_MS, MERMLAID_PREVIEW_DEBOUNCE_MS } from './mermalaidTiming'
+
+describe('mermalaidTiming (README debounce contract)', () => {
+  it('preview and editor auto-save use the same documented delay', () => {
+    expect(MERMLAID_PREVIEW_DEBOUNCE_MS).toBe(500)
+    expect(MERMLAID_EDITOR_AUTOSAVE_DEBOUNCE_MS).toBe(500)
+    expect(MERMLAID_PREVIEW_DEBOUNCE_MS).toBe(MERMLAID_EDITOR_AUTOSAVE_DEBOUNCE_MS)
+  })
+})

--- a/src/constants/mermalaidTiming.ts
+++ b/src/constants/mermalaidTiming.ts
@@ -1,0 +1,6 @@
+/**
+ * UI timing documented in README (Live preview + auto-save debounce).
+ * Keep in sync with {@link ../components/Preview.tsx} and {@link ../components/Editor.tsx}.
+ */
+export const MERMLAID_PREVIEW_DEBOUNCE_MS = 500
+export const MERMLAID_EDITOR_AUTOSAVE_DEBOUNCE_MS = 500

--- a/src/contexts/ThemeContext.test.tsx
+++ b/src/contexts/ThemeContext.test.tsx
@@ -1,0 +1,31 @@
+/**
+ * README § Dark/Light + beautiful-mermaid Themes — persisted diagram theme id.
+ */
+import { render, screen } from '@testing-library/react'
+import { beforeEach, describe, expect, it } from 'vitest'
+import { useTheme } from '../hooks/useTheme'
+import { DEFAULT_MERMAID_THEME_ID } from '../utils/mermaidThemes'
+import { ThemeProvider } from './ThemeContext'
+
+function ThemeLabel() {
+  const { mermaidTheme } = useTheme()
+  return <span data-testid="theme">{mermaidTheme}</span>
+}
+
+describe('ThemeProvider', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('falls back to default when localStorage holds an unknown theme id', () => {
+    localStorage.setItem('mermalaid-mermaid-theme', 'not-a-valid-theme-id')
+
+    render(
+      <ThemeProvider>
+        <ThemeLabel />
+      </ThemeProvider>,
+    )
+
+    expect(screen.getByTestId('theme').textContent).toBe(DEFAULT_MERMAID_THEME_ID)
+  })
+})

--- a/src/contexts/ToastContext.test.tsx
+++ b/src/contexts/ToastContext.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * README § Toast Notifications — feedback for save / export / errors.
+ */
+import { act, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useToast } from '../hooks/useToast'
+import { ToastProvider } from './ToastContext'
+
+function Trigger() {
+  const { showToast } = useToast()
+  return (
+    <button type="button" onClick={() => showToast('Fixture message', 'success')}>
+      Show
+    </button>
+  )
+}
+
+describe('ToastProvider', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('showToast renders message until auto-dismiss', () => {
+    render(
+      <ToastProvider>
+        <Trigger />
+      </ToastProvider>,
+    )
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show' }))
+    expect(screen.getByText('Fixture message')).toBeInTheDocument()
+
+    act(() => {
+      vi.advanceTimersByTime(3500)
+    })
+
+    expect(screen.queryByText('Fixture message')).not.toBeInTheDocument()
+  })
+})

--- a/src/hooks/useUndoRedo.test.tsx
+++ b/src/hooks/useUndoRedo.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * README § Visual Editor — undo/redo stack for React Flow edits.
+ */
+import type { Edge, Node } from '@xyflow/react'
+import { act, renderHook } from '@testing-library/react'
+import { describe, expect, it } from 'vitest'
+import { useUndoRedo } from './useUndoRedo'
+
+function stubNode(id: string): Node {
+  return {
+    id,
+    position: { x: 0, y: 0 },
+    data: {},
+  }
+}
+
+describe('useUndoRedo', () => {
+  it('undo returns the latest pushed snapshot (state before last change)', () => {
+    const { result } = renderHook(() => useUndoRedo(10))
+
+    const beforeOp1 = { nodes: [stubNode('1')], edges: [] as Edge[] }
+    const beforeOp2 = { nodes: [stubNode('1'), stubNode('2')], edges: [] as Edge[] }
+    const current = { nodes: [stubNode('1'), stubNode('2'), stubNode('3')], edges: [] as Edge[] }
+
+    act(() => {
+      result.current.pushState(beforeOp1)
+      result.current.pushState(beforeOp2)
+    })
+
+    let restored: typeof beforeOp1 | null = null
+    act(() => {
+      restored = result.current.undo(current)
+    })
+
+    expect(restored).toEqual(beforeOp2)
+
+    let redone: typeof current | null = null
+    act(() => {
+      redone = result.current.redo(beforeOp2)
+    })
+
+    expect(redone).toEqual(current)
+  })
+})

--- a/src/nativeAppMenu.ts
+++ b/src/nativeAppMenu.ts
@@ -346,7 +346,7 @@ async function buildAndSetAppMenu(): Promise<void> {
     items: [
       await MenuItem.new({
         id: 'help_engine_version',
-        text: 'Mermalaid Engine Version',
+        text: 'About Mermalaid',
         action: () => getHandlers().onEngineVersion(),
       }),
       await MenuItem.new({

--- a/src/test/fixtures/architecture.anonymized.md
+++ b/src/test/fixtures/architecture.anonymized.md
@@ -1,0 +1,205 @@
+---
+document: anonymized-architecture-fixture
+# YAML comments use # — not part of Mermaid
+visibility: fixture-only
+---
+
+# Kestrel — sample system architecture (anonymized test fixture)
+
+```mermaid
+graph TB
+    %% Synthetic diagram: structure-only regression fixture
+    subgraph "ClientShell"
+        Shell["Shell<br/>(React / something)"]
+
+        subgraph "Flux Views"
+            VCreate["Create View"]
+            VDetail["Detail View"]
+            VCal["Calendar View"]
+        end
+
+        Shell --> VCreate
+        Shell --> VDetail
+        Shell --> VCal
+    end
+
+    subgraph "AppServer (Node)"
+        Routes["Route Handlers"]
+
+        subgraph BE ["WidgetOrchestrator ⚙️"]
+            direction TB
+            CapA["Capacity<br/><i>guess hours</i>"]
+            SlotA["Slots<br/><i>buffers</i>"]
+            BookA["Booking<br/><i>place units</i>"]
+            ApproveA["Approvals<br/><i>manager gate</i>"]
+            DataA["Aggregation<br/><i>enrich drafts</i>"]
+        end
+
+        OrmLayer["ORM Layer"]
+
+        Routes --> BE
+        Routes --> OrmLayer
+    end
+
+    subgraph "External Mesh"
+        subgraph "Private Network API"
+            Upstream["Upstream API<br/>(GraphQL)<br/><i>IP allowlist</i>"]
+        end
+
+        subgraph "Edge Cache Layer"
+            Edge["Edge CDN"]
+            PodX["worker-pod-x"]
+            PodY["worker-pod-y"]
+            PodZ["… more workers"]
+            Edge --> PodX
+            Edge --> PodY
+            Edge --> PodZ
+        end
+
+        SSOGate["SSO<br/>(OAuth)"]
+    end
+
+    subgraph "Persistence"
+        WAL[("WalnutSQL<br/>(hosted)")]
+    end
+
+    VCreate --> Routes
+    VDetail --> Routes
+    VCal --> Routes
+    Shell -- "shardKey" --> SSOGate
+
+    Routes -- "GraphQL<br/>orders, widgets,<br/>status blobs" --> Upstream
+    Routes -. "REST via Edge<br/>printer-ish data<br/>(future — not MVP)" .-> Edge
+    OrmLayer -- "widgets, bookings,<br/>slots, knobs" --> WAL
+
+    BE -- "read orders &<br/>widgets" --> Upstream
+    BE -- "read & write local<br/>widget state" --> OrmLayer
+
+    style Shell fill:#0070f3,color:#fff
+    style Routes fill:#0070f3,color:#fff
+    style OrmLayer fill:#2D3748,color:#fff
+    style Upstream fill:#FF9900,color:#fff
+    style Edge fill:#FF9900,color:#fff,stroke-dasharray: 5 5
+    style SSOGate fill:#6C47FF,color:#fff
+    style WAL fill:#336791,color:#fff
+    style BE fill:none,stroke:#F59E0B,stroke-width:2px,stroke-dasharray: 5 5
+    style CapA fill:#F59E0B,color:#fff
+    style SlotA fill:#F59E0B,color:#fff
+    style BookA fill:#F59E0B,color:#fff
+    style ApproveA fill:#F59E0B,color:#fff
+    style DataA fill:#F59E0B,color:#fff
+    style VCreate fill:#10B981,color:#fff
+    style VDetail fill:#10B981,color:#fff
+    style VCal fill:#10B981,color:#fff
+```
+
+> **Note:** The dashed “WidgetOrchestrator” group is embedded in the app server in this fiction.
+
+> **Note:** The “Edge Cache” path is a placeholder — MVP only talks to Upstream.
+
+---
+
+## Data ownership (anonymized)
+
+| Owner | Storage | Data |
+|---|---|---|
+| **Local app** | WalnutSQL via ORM | Widgets, bookings, slot holds, knobs |
+| **Upstream** | Private network | Orders, widgets, fulfilment blobs |
+| **Edge workers** | On-prem → CDN | Capacity hints *(future)* |
+
+## Data flow
+
+| From | To | Protocol | Data |
+|---|---|---|---|
+| Shell | Routes | HTTP | Views hit routes |
+| Routes | WidgetOrchestrator | Internal | Capacity math |
+| Routes | Upstream | GraphQL | Orders / status |
+| Routes | Edge | REST | Machine hints *(future)* |
+| WidgetOrchestrator | WalnutSQL | SQL | Read/write local state |
+| WidgetOrchestrator | Upstream | GraphQL | Read remote orders |
+
+---
+
+## WidgetOrchestrator
+
+It pretends to:
+
+- **Guess hours** for a widget run
+- **Manage slots** with buffers
+- **Book widgets** into slots
+- **Approvals** with a manager gate
+- **Aggregate** draft data from Upstream for the shell
+
+## Auth
+
+**SSOGate** with OAuth. Routes authenticate every call.
+
+---
+
+## Lifecycle (nonsense states)
+
+```mermaid
+stateDiagram-v2
+    [*] --> ORANGE
+    ORANGE --> MARBLE : Quokka submits
+    MARBLE --> TEAL : Llama approves
+    MARBLE --> PLUM : Llama rejects
+    TEAL --> CORAL : Otter books slot
+    CORAL --> INDIGO : Robot starts work
+    INDIGO --> GOLD : Robot finishes
+
+    ORANGE --> SILVER : Anyone cancels early
+    MARBLE --> SILVER : Anyone cancels mid
+    TEAL --> SILVER : Anyone cancels mid
+    CORAL --> SILVER : Admin cancels
+
+    PLUM --> [*]
+    GOLD --> [*]
+    SILVER --> [*]
+```
+
+> **Note:** `PLUM` is terminal but can be **cloned** into a fresh `ORANGE`.
+
+| Hop | Who | Blurb |
+|---|---|---|
+| ORANGE → MARBLE | Quokka | Validates fields |
+| MARBLE → TEAL | Llama | Approves |
+| MARBLE → PLUM | Llama | Rejects with reason |
+| TEAL → CORAL | Otter / Admin | Books slot with version check |
+| CORAL → INDIGO | Robot | Production begins |
+| INDIGO → GOLD | Robot | Production ends |
+| * → SILVER | Mixed | Cancel path |
+
+**Concurrency**: optimistic `version` column on rows.
+
+---
+
+## Upstream integration (fake)
+
+- Static `API_TOKEN` header today
+- Future: SSO JWT exchange
+
+The sections below are generic placeholders about snapshots and caching — still markdown tables:
+
+| Upstream status | Behavior |
+|---|---|
+| **OK** | Live fetch |
+| **Slow (> 5s)** | Stale banner |
+| **Down** | Snapshot only |
+
+---
+
+## Hosting blurb (trimmed)
+
+| Constraint | Why |
+|---|---|
+| **Stable egress IP** | Allowlist |
+| **Full SSR** | Auth on every page |
+| **DB pool** | Connection limits |
+
+### Comparison
+
+| | Lambda-ish | PaaS | Containers |
+|---|---|---|---|
+| Egress | NAT | Paid feature | VPC |
+| SSR | Yes | Yes | Yes |

--- a/src/test/markdownArchitectureDocument.test.ts
+++ b/src/test/markdownArchitectureDocument.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression tests for large Markdown files that embed multiple Mermaid diagrams.
+ * Fixture: `fixtures/architecture.anonymized.md` — full doc shape (YAML, tables,
+ * `---`, `%%` comments, nested subgraphs, styles, quoted edges, stateDiagram-v2)
+ * with fictional names and labels (no real product terminology).
+ */
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+import {
+  extractAllMermaidBlocks,
+  extractMermaidCode,
+  replaceMermaidBlock,
+} from '../utils/mermaidCodeBlock'
+import { normalizeMermaidForBeautifulMermaid } from '../utils/normalizeMermaidForBeautifulMermaid'
+import { parseMermaidFlowchart } from '../utils/mermaidParser'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+const FIXTURE_PATH = join(__dirname, 'fixtures', 'architecture.anonymized.md')
+
+/** Quoted edge label used in the first diagram (must normalize to pipe form). */
+const QUOTED_EDGE_LABEL = 'shardKey'
+
+describe('markdown documents with multiple Mermaid diagrams', () => {
+  it('anonymized architecture fixture: fenced blocks, normalization, replaceMermaidBlock', () => {
+    const content = readFileSync(FIXTURE_PATH, 'utf8')
+
+    expect(content.trimStart().startsWith('---\n')).toBe(true)
+    expect(content).toMatch(/^---\n[\s\S]*?\n---\n/)
+    expect(content).toMatch(/\n#\s+YAML comments use #/m)
+
+    const blocks = extractAllMermaidBlocks(content)
+    expect(blocks.length).toBe(2)
+
+    expect(extractMermaidCode(content)).toBe(blocks[0].code)
+
+    const flow = blocks[0].code
+    const state = blocks[1].code
+
+    expect(flow).toContain('%%')
+    expect(flow).toMatch(/graph\s+TB/i)
+    expect(flow).toContain('subgraph')
+    expect(flow).toMatch(/--\s*"[^"]+"\s*-->/)
+
+    const normalized = normalizeMermaidForBeautifulMermaid(flow)
+    expect(normalized).not.toMatch(new RegExp(`--\\s*"${QUOTED_EDGE_LABEL}"\\s*-->`))
+    expect(normalized).toMatch(new RegExp(`-->\\|${QUOTED_EDGE_LABEL}\\|`))
+
+    const parsed = parseMermaidFlowchart(flow)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.type).toMatch(/flowchart|graph/)
+    expect(parsed!.direction).toBe('TD')
+    expect(parsed!.nodes.length).toBeGreaterThan(10)
+    expect(parsed!.edges.length).toBeGreaterThan(5)
+
+    expect(parseMermaidFlowchart(state)).toBeNull()
+    expect(state).toMatch(/stateDiagram-v2/i)
+
+    const patched = replaceMermaidBlock(content, blocks[1], 'stateDiagram-v2\n    [*] --> Patched')
+    const after = extractAllMermaidBlocks(patched)
+    expect(after.length).toBe(2)
+    expect(after[1].code).toContain('[*] --> Patched')
+  })
+})

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,0 +1,56 @@
+import '@testing-library/jest-dom/vitest'
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  configurable: true,
+  value: (query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    dispatchEvent: () => false,
+  }),
+})
+
+globalThis.ResizeObserver = class ResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+/** Mermaid measures labels via `getBBox`; jsdom does not implement it. */
+if (typeof SVGElement !== 'undefined') {
+  const proto = SVGElement.prototype as SVGElement & { getBBox?: () => DOMRect }
+  if (typeof proto.getBBox !== 'function') {
+    proto.getBBox = function (): DOMRect {
+      return {
+        x: 0,
+        y: 0,
+        width: 80,
+        height: 20,
+        top: 0,
+        right: 80,
+        bottom: 20,
+        left: 0,
+        toJSON() {
+          return {}
+        },
+      }
+    }
+  }
+}
+
+globalThis.IntersectionObserver = class IntersectionObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+  takeRecords(): IntersectionObserverEntry[] {
+    return []
+  }
+  readonly root: Element | Document | null = null
+  readonly rootMargin = ''
+  readonly thresholds: ReadonlyArray<number> = []
+} as unknown as typeof IntersectionObserver

--- a/src/utils/aiErrorFixer.test.ts
+++ b/src/utils/aiErrorFixer.test.ts
@@ -1,0 +1,50 @@
+/**
+ * README § AI Syntax Fix — local API key storage + response cleanup.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  clearApiKey,
+  fixMermaidErrorWithAI,
+  getStoredApiKey,
+  storeApiKey,
+} from './aiErrorFixer'
+
+describe('AI key storage (local only, README)', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  afterEach(() => {
+    localStorage.clear()
+  })
+
+  it('round-trips openai-api-key in localStorage', () => {
+    expect(getStoredApiKey()).toBeNull()
+    storeApiKey('sk-local')
+    expect(getStoredApiKey()).toBe('sk-local')
+    clearApiKey()
+    expect(getStoredApiKey()).toBeNull()
+  })
+})
+
+describe('fixMermaidErrorWithAI', () => {
+  it('strips ```mermaid fences from model output', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: '```mermaid\ngraph TD\n  A --> B\n```' } }],
+      }),
+    })
+    vi.stubGlobal('fetch', fetchMock)
+
+    const fixed = await fixMermaidErrorWithAI('broken', 'syntax error', 'sk-test')
+
+    expect(fixed).toBe('graph TD\n  A --> B')
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://api.openai.com/v1/chat/completions',
+      expect.objectContaining({ method: 'POST' }),
+    )
+
+    vi.unstubAllGlobals()
+  })
+})

--- a/src/utils/diagramImportFiles.test.ts
+++ b/src/utils/diagramImportFiles.test.ts
@@ -1,0 +1,20 @@
+/**
+ * README § File Management — Open `.mmd`, `.txt`, or `.md` files.
+ */
+import { describe, expect, it } from 'vitest'
+import { isDiagramImportFileName } from './diagramImportFiles'
+
+describe('isDiagramImportFileName', () => {
+  it('accepts the three documented extensions (case-insensitive)', () => {
+    expect(isDiagramImportFileName('x.mmd')).toBe(true)
+    expect(isDiagramImportFileName('X.MMD')).toBe(true)
+    expect(isDiagramImportFileName('notes.txt')).toBe(true)
+    expect(isDiagramImportFileName('doc.md')).toBe(true)
+  })
+
+  it('rejects other extensions', () => {
+    expect(isDiagramImportFileName('x.json')).toBe(false)
+    expect(isDiagramImportFileName('x.mermaid')).toBe(false)
+    expect(isDiagramImportFileName('readme')).toBe(false)
+  })
+})

--- a/src/utils/diagramImportFiles.ts
+++ b/src/utils/diagramImportFiles.ts
@@ -1,0 +1,8 @@
+/**
+ * README: Open `.mmd`, `.txt`, or `.md` — used for drag-and-drop import.
+ * @see {@link ../App.tsx} handleDrop
+ */
+export function isDiagramImportFileName(fileName: string): boolean {
+  const n = fileName.toLowerCase()
+  return n.endsWith('.mmd') || n.endsWith('.txt') || n.endsWith('.md')
+}

--- a/src/utils/env.test.ts
+++ b/src/utils/env.test.ts
@@ -1,0 +1,28 @@
+/**
+ * README § AI Syntax Fix — `VITE_ENABLE_AI_FIXER`, optional API key env.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+describe('env helpers (README AI fixer toggles)', () => {
+  beforeEach(() => {
+    vi.unstubAllEnvs()
+    vi.resetModules()
+  })
+
+  it('isAIFixerEnabled is false when VITE_ENABLE_AI_FIXER is false', async () => {
+    vi.stubEnv('VITE_ENABLE_AI_FIXER', 'false')
+    const { isAIFixerEnabled } = await import('./env')
+    expect(isAIFixerEnabled()).toBe(false)
+  })
+
+  it('isAIFixerEnabled defaults to true when unset', async () => {
+    const { isAIFixerEnabled } = await import('./env')
+    expect(isAIFixerEnabled()).toBe(true)
+  })
+
+  it('getOpenAIApiKey reads VITE_OPENAI_API_KEY', async () => {
+    vi.stubEnv('VITE_OPENAI_API_KEY', 'sk-test')
+    const { getOpenAIApiKey } = await import('./env')
+    expect(getOpenAIApiKey()).toBe('sk-test')
+  })
+})

--- a/src/utils/mermaidCodeBlock.test.ts
+++ b/src/utils/mermaidCodeBlock.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import {
+  extractAllMermaidBlocks,
+  extractMermaidCode,
+  replaceMermaidBlock,
+} from './mermaidCodeBlock'
+
+describe('extractMermaidCode', () => {
+  it('returns empty string for empty input', () => {
+    expect(extractMermaidCode('')).toBe('')
+  })
+
+  it('unwraps a single ```mermaid fenced block', () => {
+    const src = 'Intro\n\n```mermaid\ngraph TD\n  A --> B\n```\n\nOutro'
+    expect(extractMermaidCode(src)).toBe('graph TD\n  A --> B')
+  })
+
+  it('returns trimmed plain mermaid when no fence', () => {
+    expect(extractMermaidCode('  graph LR\n    X --> Y  ')).toBe('graph LR\n    X --> Y')
+  })
+})
+
+describe('extractAllMermaidBlocks', () => {
+  it('returns empty array when no blocks', () => {
+    expect(extractAllMermaidBlocks('graph TD\nA-->B')).toEqual([])
+  })
+
+  it('extracts multiple blocks with offsets', () => {
+    const text = 'a\n```mermaid\none\n```\nb\n```mermaid\ntwo\n```'
+    const blocks = extractAllMermaidBlocks(text)
+    expect(blocks).toHaveLength(2)
+    expect(blocks[0].code).toBe('one')
+    expect(blocks[1].code).toBe('two')
+    expect(text.slice(blocks[0].start, blocks[0].end)).toContain('one')
+    expect(text.slice(blocks[1].start, blocks[1].end)).toContain('two')
+  })
+})
+
+describe('replaceMermaidBlock', () => {
+  it('replaces the targeted block only', () => {
+    const text = '```mermaid\nold\n```'
+    const [block] = extractAllMermaidBlocks(text)
+    expect(block).toBeDefined()
+    const next = replaceMermaidBlock(text, block, 'new')
+    expect(next).toBe('```mermaid\nnew\n```')
+  })
+})

--- a/src/utils/mermaidDiagramKinds.test.ts
+++ b/src/utils/mermaidDiagramKinds.test.ts
@@ -1,0 +1,56 @@
+/**
+ * README § "Mermaid Diagram Types Supported" — ensure starters are recognized after YAML strip.
+ */
+import { describe, expect, it } from 'vitest'
+import { isEditableDiagram } from './mermaidParser'
+import { parseMermaidWithConfig } from './mermaidYamlConfig'
+
+/** First non-empty, non-%% line of diagram body (after optional Mermaid YAML header). */
+function firstDiagramLine(diagramSource: string): string {
+  const { code } = parseMermaidWithConfig(diagramSource.trim())
+  const line =
+    code
+      .split('\n')
+      .map((l) => l.trim())
+      .find((l) => l.length > 0 && !l.startsWith('%%')) ?? ''
+  return line
+}
+
+describe('README diagram type keywords', () => {
+  const cases: Array<{ name: string; sample: string; head: string | RegExp }> = [
+    { name: 'flowchart', sample: 'flowchart TD\n  A --> B', head: /^flowchart\s+TD/i },
+    { name: 'graph', sample: 'graph LR\n  A --> B', head: /^graph\s+LR/i },
+    { name: 'sequenceDiagram', sample: 'sequenceDiagram\n  A->>B: hi', head: /^sequenceDiagram$/i },
+    { name: 'classDiagram', sample: 'classDiagram\n  class A', head: /^classDiagram$/i },
+    { name: 'classDiagram-v2', sample: 'classDiagram-v2\n  class A', head: /^classDiagram-v2$/i },
+    { name: 'stateDiagram-v2', sample: 'stateDiagram-v2\n  [*] --> A', head: /^stateDiagram-v2$/i },
+    { name: 'stateDiagram', sample: 'stateDiagram\n  [*] --> A', head: /^stateDiagram$/i },
+    { name: 'erDiagram', sample: 'erDiagram\n  ENTITY ||--o{ OTHER : rel', head: /^erDiagram$/i },
+    { name: 'journey', sample: 'journey\n  title My journey', head: /^journey$/i },
+    { name: 'gantt', sample: 'gantt\n  title A', head: /^gantt$/i },
+    { name: 'pie', sample: 'pie title Data\n  "a": 1', head: /^pie\s+title/i },
+    { name: 'gitGraph', sample: 'gitGraph\n  commit', head: /^gitGraph$/i },
+  ]
+
+  it.each(cases)('$name: first line matches expected header', ({ sample, head }) => {
+    const line = firstDiagramLine(sample)
+    expect(line).toMatch(head)
+  })
+
+  it('flowchart/graph inside YAML-wrapped block still detected', () => {
+    const wrapped = `---
+config:
+  theme: dark
+---
+
+graph TD
+  A-->B`
+    expect(firstDiagramLine(wrapped)).toMatch(/^graph\s+TD/i)
+  })
+
+  it('visual editor eligibility matches README (flowcharts only)', () => {
+    expect(isEditableDiagram('flowchart TD\nA-->B')).toBe(true)
+    expect(isEditableDiagram('sequenceDiagram\nA->>B:x')).toBe(false)
+    expect(isEditableDiagram('classDiagram\nclass X')).toBe(false)
+  })
+})

--- a/src/utils/mermaidParser.test.ts
+++ b/src/utils/mermaidParser.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { isEditableDiagram, parseMermaidFlowchart } from './mermaidParser'
+
+describe('isEditableDiagram', () => {
+  it('accepts flowchart and graph with supported directions', () => {
+    expect(isEditableDiagram('flowchart TD\nA-->B')).toBe(true)
+    expect(isEditableDiagram('graph LR\nA-->B')).toBe(true)
+    expect(isEditableDiagram('  graph TB\n')).toBe(true)
+  })
+
+  it('rejects non-flowchart diagram types', () => {
+    expect(isEditableDiagram('sequenceDiagram\nA->>B: hi')).toBe(false)
+    expect(isEditableDiagram('pie title T\n"x": 1')).toBe(false)
+  })
+
+  it('rejects graph without direction keyword', () => {
+    expect(isEditableDiagram('graph\nA-->B')).toBe(false)
+  })
+})
+
+describe('parseMermaidFlowchart', () => {
+  it('returns null for non-flowchart input', () => {
+    expect(parseMermaidFlowchart('info')).toBeNull()
+  })
+
+  it('parses nodes, edges, and direction', () => {
+    const code = `flowchart TD
+    A[Start] --> B{Choice}
+    B -->|yes| C[Done]
+    B -->|no| D[Retry]`
+    const parsed = parseMermaidFlowchart(code)
+    expect(parsed).not.toBeNull()
+    expect(parsed!.type).toBe('flowchart')
+    expect(parsed!.direction).toBe('TD')
+    expect(parsed!.nodes.map((n) => n.id).sort()).toEqual(['A', 'B', 'C', 'D'].sort())
+    expect(parsed!.edges.length).toBeGreaterThanOrEqual(3)
+    const ab = parsed!.edges.find((e) => e.source === 'A' && e.target === 'B')
+    expect(ab).toBeDefined()
+    expect(ab!.type).toBe('arrow')
+  })
+
+  it('maps TB and DT to TD/BT respectively', () => {
+    const td = parseMermaidFlowchart('graph TB\nA-->B')
+    expect(td?.direction).toBe('TD')
+    const bt = parseMermaidFlowchart('graph DT\nA-->B')
+    expect(bt?.direction).toBe('BT')
+  })
+})

--- a/src/utils/mermaidThemes.test.ts
+++ b/src/utils/mermaidThemes.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_MERMAID_THEME_ID,
+  getAppThemeCssVars,
+  getMermaidThemeLabel,
+  getMermaidThemeOptions,
+  isAppThemeDark,
+  isValidMermaidThemeId,
+} from './mermaidThemes'
+
+describe('getMermaidThemeLabel', () => {
+  it('title-cases kebab-case ids', () => {
+    expect(getMermaidThemeLabel('github-light')).toBe('Github Light')
+    expect(getMermaidThemeLabel('tokyo-night')).toBe('Tokyo Night')
+  })
+})
+
+describe('isValidMermaidThemeId', () => {
+  it('accepts known theme keys', () => {
+    expect(isValidMermaidThemeId(DEFAULT_MERMAID_THEME_ID)).toBe(true)
+  })
+
+  it('rejects unknown strings', () => {
+    expect(isValidMermaidThemeId('not-a-real-theme-xyz')).toBe(false)
+  })
+})
+
+describe('getMermaidThemeOptions', () => {
+  it('falls back to default for invalid id', () => {
+    const opt = getMermaidThemeOptions('__invalid__')
+    expect(opt).toEqual(getMermaidThemeOptions(DEFAULT_MERMAID_THEME_ID))
+  })
+})
+
+describe('getAppThemeCssVars', () => {
+  it('maps invalid theme id to the same vars as the default theme', () => {
+    const invalid = getAppThemeCssVars('__invalid__')
+    const def = getAppThemeCssVars(DEFAULT_MERMAID_THEME_ID)
+    expect(invalid).toEqual(def)
+  })
+
+  it('maps a valid theme to string CSS variables', () => {
+    const vars = getAppThemeCssVars(DEFAULT_MERMAID_THEME_ID)
+    expect(typeof vars['--app-bg']).toBe('string')
+    expect(vars['--app-bg'].length).toBeGreaterThan(0)
+  })
+})
+
+describe('isAppThemeDark', () => {
+  it('marks known dark themes', () => {
+    expect(isAppThemeDark('github-dark')).toBe(true)
+    expect(isAppThemeDark('dracula')).toBe(true)
+  })
+
+  it('treats default light theme as not dark', () => {
+    expect(isAppThemeDark(DEFAULT_MERMAID_THEME_ID)).toBe(false)
+  })
+})

--- a/src/utils/mermaidYamlConfig.test.ts
+++ b/src/utils/mermaidYamlConfig.test.ts
@@ -1,0 +1,111 @@
+/**
+ * README § beautiful-mermaid Themes / YAML — Mermaid YAML config header (issue #30).
+ */
+import { describe, expect, it } from 'vitest'
+import {
+  mapMermaidConfigToThemeOptions,
+  parseMermaidConfigForOfficialRenderer,
+  parseMermaidWithConfig,
+  replaceDiagramInBlock,
+} from './mermaidYamlConfig'
+
+describe('parseMermaidWithConfig', () => {
+  it('returns plain code when there is no frontmatter', () => {
+    const raw = 'graph LR\n  A --> B'
+    expect(parseMermaidWithConfig(raw)).toEqual({ code: 'graph LR\n  A --> B' })
+  })
+
+  it('strips YAML and returns diagram code', () => {
+    const raw = `---
+config:
+  theme: dark
+---
+
+flowchart TD
+  X --> Y`
+    const r = parseMermaidWithConfig(raw)
+    expect(r.code).toBe('flowchart TD\n  X --> Y')
+    expect(r.yamlHeader).toBeDefined()
+  })
+
+  it('exposes config when themeVariables are present (for beautiful-mermaid path)', () => {
+    const raw = `---
+config:
+  themeVariables:
+    primaryColor: "#112233"
+    primaryTextColor: "#aabbcc"
+---
+
+graph TD
+  A-->B`
+    const r = parseMermaidWithConfig(raw)
+    expect(r.code).toBe('graph TD\n  A-->B')
+    expect(r.config?.themeVariables?.primaryColor).toBe('#112233')
+  })
+
+  it('ignores broken YAML and still returns diagram body', () => {
+    const raw = `---
+this is: not: valid yaml [[[
+---
+
+pie title T
+"x": 1`
+    const r = parseMermaidWithConfig(raw)
+    expect(r.code).toContain('pie title')
+  })
+})
+
+describe('parseMermaidConfigForOfficialRenderer', () => {
+  it('keeps theme-only config for official renderer', () => {
+    const raw = `---
+config:
+  theme: forest
+---
+
+graph TD
+  A-->B`
+    const c = parseMermaidConfigForOfficialRenderer(raw)
+    expect(c?.theme).toBe('forest')
+  })
+})
+
+describe('mapMermaidConfigToThemeOptions', () => {
+  it('maps themeVariables into beautiful-mermaid option shape', () => {
+    const opts = mapMermaidConfigToThemeOptions({
+      themeVariables: {
+        tertiaryColor: '#111111',
+        primaryTextColor: '#222222',
+        lineColor: '#333333',
+        secondaryColor: '#444444',
+        primaryColor: '#555555',
+        primaryBorderColor: '#666666',
+      },
+    })
+    expect(opts.bg).toBe('#111111')
+    expect(opts.fg).toBe('#222222')
+    expect(opts.line).toBe('#333333')
+  })
+})
+
+describe('replaceDiagramInBlock', () => {
+  it('preserves YAML header when updating diagram body', () => {
+    const block = `---
+config:
+  themeVariables:
+    primaryColor: "#fff"
+---
+
+graph TD
+  Old-->Gone`
+    const next = replaceDiagramInBlock(block, 'graph TD\n  New-->Stay')
+    expect(next.startsWith('---\n')).toBe(true)
+    expect(next).toContain('graph TD\n  New-->Stay')
+    expect(next).not.toContain('Old-->Gone')
+  })
+
+  it('returns only new code when block had no frontmatter', () => {
+    expect(replaceDiagramInBlock('graph LR\nA-->B', 'pie title X\n"y": 1')).toBe(
+      'pie title X\n"y": 1',
+    )
+  })
+})

--- a/src/utils/mermalaidInfoText.test.ts
+++ b/src/utils/mermalaidInfoText.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => false,
+}))
+
+import {
+  buildMermalaidInfoText,
+  isMermaidAboutKeywordOnly,
+  mermalaidAboutMarkupFromPlainText,
+} from './mermalaidInfoText'
+
+describe('isMermaidAboutKeywordOnly', () => {
+  it('is true for lone info keyword (case-insensitive)', () => {
+    expect(isMermaidAboutKeywordOnly('info')).toBe(true)
+    expect(isMermaidAboutKeywordOnly('INFO')).toBe(true)
+    expect(isMermaidAboutKeywordOnly('  info  ')).toBe(true)
+  })
+
+  it('ignores empty lines, whitespace, and %% comments', () => {
+    expect(isMermaidAboutKeywordOnly('\n\n%% note\ninfo\n')).toBe(true)
+    expect(isMermaidAboutKeywordOnly('%%\ninfo')).toBe(true)
+  })
+
+  it('is false when other content remains after filtering', () => {
+    expect(isMermaidAboutKeywordOnly('info\ngraph TD')).toBe(false)
+    expect(isMermaidAboutKeywordOnly('infoline')).toBe(false)
+  })
+
+  it('strips zero-width characters before matching', () => {
+    expect(isMermaidAboutKeywordOnly('\u200Binfo')).toBe(true)
+  })
+})
+
+describe('mermalaidAboutMarkupFromPlainText', () => {
+  it('escapes HTML and wraps in preview class', () => {
+    const html = mermalaidAboutMarkupFromPlainText('<Mermalaid> & "v"')
+    expect(html).toContain('&lt;Mermalaid&gt;')
+    expect(html).toContain('&amp;')
+    expect(html).toContain('&quot;')
+    expect(html).toContain('class="preview-about-mermalaid"')
+  })
+})
+
+describe('buildMermalaidInfoText (web)', () => {
+  it('includes version, Web runtime, engines, and project link', async () => {
+    const text = await buildMermalaidInfoText()
+    expect(text).toMatch(/Mermalaid \d+\.\d+\.\d+/)
+    expect(text).toContain('Web')
+    expect(text).not.toContain('App bundle version')
+    expect(text).toContain('Official Mermaid')
+    expect(text).toContain('beautiful-mermaid')
+    expect(text).toContain('github.com/highvoltag3/mermalaid')
+  })
+})

--- a/src/utils/mermalaidInfoText.ts
+++ b/src/utils/mermalaidInfoText.ts
@@ -1,0 +1,83 @@
+import { getIdentifier, getTauriVersion, getVersion } from '@tauri-apps/api/app'
+import { isTauri } from '@tauri-apps/api/core'
+import packageJson from '../../package.json'
+
+/**
+ * True when the diagram source is only the keyword `info` (case-insensitive).
+ * Uses the same non-empty / non-%% line filtering as beautiful-mermaid's parser so
+ * `%%\ninfo` does not fall through to legacy render and throw "Invalid mermaid header".
+ *
+ * Mermaid also defines an `info` diagram type; we reserve this pattern for Mermalaid about text.
+ */
+export function isMermaidAboutKeywordOnly(diagramCode: string): boolean {
+  const stripped = diagramCode.replace(/[\u200B-\u200D\uFEFF]/g, '')
+  const lines = stripped
+    .split('\n')
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0 && !l.startsWith('%%'))
+  return lines.length === 1 && /^info$/i.test(lines[0])
+}
+
+function dependencyRange(name: keyof typeof packageJson.dependencies): string {
+  const v = packageJson.dependencies?.[name]
+  return typeof v === 'string' ? v : 'unknown'
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}
+
+/** HTML fragment for preview pane (styles from Preview.css). */
+export function mermalaidAboutMarkupFromPlainText(text: string): string {
+  return `<pre class="preview-about-mermalaid">${escapeHtml(text)}</pre>`
+}
+
+export async function buildMermalaidInfoText(): Promise<string> {
+  const lines: string[] = [
+    `Mermalaid ${packageJson.version}`,
+    '',
+    'Runtime:',
+    isTauri() ? '  Desktop (Tauri)' : '  Web',
+  ]
+
+  if (isTauri()) {
+    try {
+      const [bundleVersion, tauriRuntime, identifier] = await Promise.all([
+        getVersion(),
+        getTauriVersion(),
+        getIdentifier(),
+      ])
+      lines.push(
+        `  App bundle version: ${bundleVersion}`,
+        `  Tauri: ${tauriRuntime}`,
+        `  Identifier: ${identifier}`,
+      )
+    } catch {
+      lines.push('  (Could not read native app metadata.)')
+    }
+  }
+
+  lines.push(
+    '',
+    'Diagram engines:',
+    `  Official Mermaid: ${dependencyRange('mermaid')}`,
+    `  beautiful-mermaid (legacy / some exports): ${dependencyRange('beautiful-mermaid')}`,
+    '',
+    'UI stack:',
+    `  React: ${dependencyRange('react')}`,
+    `  @tauri-apps/api: ${dependencyRange('@tauri-apps/api')}`,
+    '',
+    'Project:',
+    '  https://github.com/highvoltag3/mermalaid',
+  )
+
+  return lines.join('\n')
+}
+
+export async function buildMermalaidAboutPreviewHtml(): Promise<string> {
+  return mermalaidAboutMarkupFromPlainText(await buildMermalaidInfoText())
+}

--- a/src/utils/normalizeMermaidForBeautifulMermaid.test.ts
+++ b/src/utils/normalizeMermaidForBeautifulMermaid.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeMermaidForBeautifulMermaid } from './normalizeMermaidForBeautifulMermaid'
+
+describe('normalizeMermaidForBeautifulMermaid', () => {
+  it('leaves non-flowchart diagrams unchanged', () => {
+    const pie = `pie title Pets
+"Dog": 40
+"Cat": 35`
+    expect(normalizeMermaidForBeautifulMermaid(pie)).toBe(pie)
+  })
+
+  it('converts quoted edge labels to pipe form', () => {
+    const before = `graph LR
+A -- "Hello" --> B`
+    const after = normalizeMermaidForBeautifulMermaid(before)
+    expect(after).toContain('-->|Hello|')
+    expect(after).not.toContain('-- "Hello" -->')
+  })
+
+  it('normalizes thick arrow labels', () => {
+    const before = `graph TD
+A == "x" ==> B`
+    const after = normalizeMermaidForBeautifulMermaid(before)
+    expect(after).toContain('==>|x|')
+  })
+
+  it('skips comment and subgraph lines', () => {
+    const code = `graph TD
+%% comment
+subgraph S1
+A --> B
+end`
+    const out = normalizeMermaidForBeautifulMermaid(code)
+    expect(out).toContain('%% comment')
+    expect(out).toContain('subgraph S1')
+  })
+})

--- a/src/utils/officialMermaidPreview.test.ts
+++ b/src/utils/officialMermaidPreview.test.ts
@@ -1,0 +1,20 @@
+/**
+ * README § Live preview / official Mermaid path — minimal render smoke.
+ */
+import { describe, expect, it } from 'vitest'
+import { renderOfficialMermaidPreview } from './officialMermaidPreview'
+
+describe('renderOfficialMermaidPreview', () => {
+  it(
+    'returns SVG markup for a trivial flowchart',
+    { timeout: 20_000 },
+    async () => {
+      const svg = await renderOfficialMermaidPreview(
+        'graph TD\n  A["Start"] --> B["End"]',
+        false,
+        { bg: '#ffffff', fg: '#333333', line: '#999999' },
+      )
+      expect(svg.trim().toLowerCase()).toContain('<svg')
+    },
+  )
+})

--- a/src/utils/recentFiles.test.ts
+++ b/src/utils/recentFiles.test.ts
@@ -1,0 +1,52 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  addRecentFile,
+  clearRecentFiles,
+  getRecentPaths,
+  recentFileLabel,
+  removeRecentFile,
+} from './recentFiles'
+
+describe('recentFiles', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('round-trips paths and dedupes', () => {
+    addRecentFile('/a/x.mmd')
+    addRecentFile('/b/y.mmd')
+    addRecentFile('/a/x.mmd')
+    expect(getRecentPaths()).toEqual(['/a/x.mmd', '/b/y.mmd'])
+  })
+
+  it('caps list length', () => {
+    for (let i = 0; i < 15; i += 1) {
+      addRecentFile(`/p/${i}`)
+    }
+    expect(getRecentPaths().length).toBe(10)
+    expect(getRecentPaths()[0]).toBe('/p/14')
+  })
+
+  it('removeRecentFile drops one entry', () => {
+    addRecentFile('/one')
+    addRecentFile('/two')
+    removeRecentFile('/one')
+    expect(getRecentPaths()).toEqual(['/two'])
+  })
+
+  it('clearRecentFiles empties storage', () => {
+    addRecentFile('/z')
+    clearRecentFiles()
+    expect(getRecentPaths()).toEqual([])
+  })
+
+  it('recentFileLabel uses last path segment', () => {
+    expect(recentFileLabel('/Users/me/diagram.mmd')).toBe('diagram.mmd')
+    expect(recentFileLabel(String.raw`C:\dev\file.mmd`)).toBe('file.mmd')
+  })
+
+  it('getRecentPaths returns empty array for invalid JSON', () => {
+    localStorage.setItem('mermalaid-recent-files', 'not-json')
+    expect(getRecentPaths()).toEqual([])
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,13 @@
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [react()],
+  test: {
+    environment: 'jsdom',
+    setupFiles: ['./src/test/setup.ts'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    css: true,
+    testTimeout: 15_000,
+  },
+})


### PR DESCRIPTION
## Summary
Adds automated regression coverage across unit, integration, and E2E tests, plus CI to run them on every PR.

## Key Changes
- Added **Vitest + Testing Library** test setup for web/unit coverage
- Added **Playwright E2E** coverage for landing/editor flows and core toolbar actions
- Added **GitHub Actions** workflow to run unit and E2E tests in CI
- Covered key utilities and app behavior including Mermaid parsing, YAML config, themes, about/info text, recent files, env helpers, and import handling
- Centralized shared timing constants and reused import file checks in app code
- Included a small Playwright fix for `Ctrl+N` shortcut handling

## Notes
- Improves regression protection for core editor and preview flows
- Includes prior About/`info` support changes and Cargo.lock version sync already present in this branch