### PR TITLE
Deploy Appwrite site on keepalive schedule

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,7 +2,7 @@
 
 This directory contains GitHub Actions workflows for automating tasks in this repository.
 
-**Appwrite Sites:** This repo does **not** deploy to Appwrite via GitHub Actions. Connect your GitHub repository in the [Appwrite Console](https://cloud.appwrite.io) (Sites → your site → VCS / Git integration) and use **Auto Deploy** on your production branch. See [DEPLOYMENT.md](../../DEPLOYMENT.md).
+**Appwrite Sites:** `keep-appwrite-active.yml` builds the web app and deploys the generated `dist` directory to Appwrite Sites every 5 days. See [DEPLOYMENT.md](../../DEPLOYMENT.md).
 
 ## Workflows
 
@@ -18,3 +18,16 @@ Automatically creates GitHub releases and builds Tauri macOS applications when v
 - macOS `.app` bundle and `.dmg` installer
 
 **Secrets:** Uses the default `GITHUB_TOKEN` only (no extra repository secrets required for this workflow).
+
+### `keep-appwrite-active.yml`
+
+Builds and deploys the static web app to Appwrite Sites so the project receives a real deployment on a recurring schedule.
+
+**Trigger:** Every 5 days and manual dispatch.
+
+**Secrets:**
+
+- `APPWRITE_ENDPOINT`
+- `APPWRITE_PROJECT_ID`
+- `APPWRITE_API_KEY`
+- `APPWRITE_SITE_ID`

--- a/.github/workflows/keep-appwrite-active.yml
+++ b/.github/workflows/keep-appwrite-active.yml
@@ -1,4 +1,4 @@
-name: keep-appwrite-active
+name: deploy-appwrite-site
 
 on:
   schedule:
@@ -6,13 +6,36 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: none
+  contents: read
+
+concurrency:
+  group: appwrite-site-deploy
+  cancel-in-progress: false
 
 jobs:
-  ping:
+  deploy:
     runs-on: ubuntu-latest
     steps:
-      - name: Ping Appwrite health
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Build static site
+        run: |
+          npm ci
+          npm run build
+
+      - name: Install Appwrite CLI
+        run: |
+          npm install -g appwrite-cli@latest
+          appwrite -v
+
+      - name: Configure Appwrite CLI
         env:
           APPWRITE_ENDPOINT: ${{ secrets.APPWRITE_ENDPOINT }}
           APPWRITE_PROJECT_ID: ${{ secrets.APPWRITE_PROJECT_ID }}
@@ -25,14 +48,69 @@ jobs:
           BASE="${APPWRITE_ENDPOINT}"
           BASE="${BASE%/}"
           if [ -z "${APPWRITE_PROJECT_ID}" ] || [ -z "${APPWRITE_API_KEY}" ]; then
-            echo "::error::Set APPWRITE_PROJECT_ID and APPWRITE_API_KEY repository secrets. Appwrite Cloud /v1/health requires them."
+            echo "::error::Set APPWRITE_PROJECT_ID and APPWRITE_API_KEY repository secrets."
             exit 1
           fi
           if [ "${BASE}" = "https://cloud.appwrite.io/v1" ] || [ "${BASE}" = "https://cloud.appwrite.io" ]; then
             echo "::error::APPWRITE_ENDPOINT must include your region host, e.g. https://<REGION>.cloud.appwrite.io/v1"
             exit 1
           fi
-          curl -sf \
-            -H "X-Appwrite-Project: ${APPWRITE_PROJECT_ID}" \
-            -H "X-Appwrite-Key: ${APPWRITE_API_KEY}" \
-            "${BASE}/health"
+          appwrite client \
+            --endpoint "${BASE}" \
+            --project-id "${APPWRITE_PROJECT_ID}" \
+            --key "${APPWRITE_API_KEY}"
+
+      - name: Deploy to Appwrite Sites
+        env:
+          APPWRITE_SITE_ID: ${{ secrets.APPWRITE_SITE_ID }}
+        run: |
+          if [ -z "${APPWRITE_SITE_ID}" ]; then
+            echo "::error::Set APPWRITE_SITE_ID to the Appwrite Site ID that serves this app."
+            exit 1
+          fi
+
+          DEPLOYMENT_JSON="$(appwrite sites create-deployment \
+            --site-id "${APPWRITE_SITE_ID}" \
+            --code dist \
+            --install-command "" \
+            --build-command "" \
+            --output-directory "." \
+            --activate true \
+            --json)"
+
+          echo "${DEPLOYMENT_JSON}"
+          DEPLOYMENT_ID="$(printf '%s' "${DEPLOYMENT_JSON}" | jq -r '.$id // empty')"
+          if [ -z "${DEPLOYMENT_ID}" ]; then
+            echo "::error::Appwrite did not return a deployment ID."
+            exit 1
+          fi
+          echo "DEPLOYMENT_ID=${DEPLOYMENT_ID}" >> "${GITHUB_ENV}"
+
+      - name: Wait for Appwrite deployment
+        env:
+          APPWRITE_SITE_ID: ${{ secrets.APPWRITE_SITE_ID }}
+        run: |
+          for attempt in $(seq 1 60); do
+            STATUS_JSON="$(appwrite sites get-deployment \
+              --site-id "${APPWRITE_SITE_ID}" \
+              --deployment-id "${DEPLOYMENT_ID}" \
+              --json)"
+            STATUS="$(printf '%s' "${STATUS_JSON}" | jq -r '.status // empty')"
+            echo "Attempt ${attempt}: deployment ${DEPLOYMENT_ID} status is ${STATUS:-unknown}"
+
+            case "${STATUS}" in
+              ready)
+                exit 0
+                ;;
+              failed|canceled)
+                echo "${STATUS_JSON}"
+                echo "::error::Appwrite deployment ${DEPLOYMENT_ID} finished with status ${STATUS}."
+                exit 1
+                ;;
+            esac
+
+            sleep 10
+          done
+
+          echo "::error::Timed out waiting for Appwrite deployment ${DEPLOYMENT_ID} to become ready."
+          exit 1

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -4,9 +4,13 @@ This guide explains how to deploy Mermalaid to Appwrite Sites.
 
 ## Prerequisites
 
-- An Appwrite account and project
-- Git repository connected to Appwrite (recommended — this is how deploys run)
+- An Appwrite account, project, and Site
 - Node.js 18+ (for local testing)
+- GitHub repository secrets for scheduled deploys:
+  - `APPWRITE_ENDPOINT` — regional endpoint such as `https://<REGION>.cloud.appwrite.io/v1`
+  - `APPWRITE_PROJECT_ID`
+  - `APPWRITE_API_KEY` — API key with permission to create and read site deployments
+  - `APPWRITE_SITE_ID`
 
 ## Build Configuration
 
@@ -85,16 +89,22 @@ VITE_ENABLE_AI_FIXER=true
 - For security, never commit `.env` files with actual API keys
 - Use `env.example` as a template (without sensitive data)
 
-### GitHub / VCS integration (recommended)
+### GitHub Actions scheduled deploy
 
-Deploys are expected to run **inside Appwrite** after you connect the repo — not via GitHub Actions in this repository.
+`.github/workflows/keep-appwrite-active.yml` deploys the app to Appwrite Sites every 5 days:
 
-1. **Repository provider**: Connect GitHub (or GitLab, etc.)
-2. **Repository**: Select this project’s repository
-3. **Production branch**: `main` (or your default branch)
-4. **Auto deploy**: Enable so pushes to that branch start a build on Appwrite’s builders (`npm install` → `npm run build` → serve `dist`)
+1. Checks out the repo
+2. Runs `npm ci`
+3. Runs `npm run build`
+4. Installs and configures the Appwrite CLI
+5. Uploads `dist` as a site deployment with `--activate true`
+6. Polls Appwrite until the deployment reports `ready`
 
-Pushes to `main` (including from `npm run release`) will trigger Appwrite only when auto deploy is on and the site is linked to the repo.
+You can also run the workflow manually from the GitHub Actions tab.
+
+### GitHub / VCS integration (optional)
+
+You can still connect the repository in Appwrite Console and enable Appwrite's own auto deploy for pushes to `main`, but the scheduled GitHub Actions workflow is the recurring deployment used to keep the site active.
 
 ### Custom Domain (Optional)
 
@@ -116,13 +126,15 @@ The preview server will serve the built files from the `dist` directory, allowin
 
 ## How deployment runs
 
-1. **Git integration (default path)** — Configure GitHub under your site in the Appwrite Console (see **GitHub / VCS integration** above). Each push to the production branch starts a deployment on Appwrite. Track status under the site’s **Deployments** tab in Appwrite (not in GitHub Actions).
+1. **Scheduled GitHub Actions workflow** — Every 5 days, GitHub Actions builds `dist`, uploads it with `appwrite sites create-deployment`, activates the deployment, and waits for Appwrite to report `ready`.
 
-2. **Console-only** — You can also start a deployment from the Appwrite Console (e.g. choose a branch, or upload a `.tar.gz` of your build output). Use the same install/build/output settings as in **Build Settings**.
+2. **Git integration** — If configured in Appwrite Console, pushes to the production branch can also start Appwrite-hosted builds.
+
+3. **Console-only** — You can also start a deployment from the Appwrite Console (e.g. choose a branch, or upload a `.tar.gz` of your build output). Use the same install/build/output settings as in **Build Settings**.
 
 ### Desktop releases (separate from the web app)
 
-`npm run release` / `npm run release:patch` etc. bump the version, push `main`, and push a `v*` tag. That triggers **only** [.github/workflows/release.yml](.github/workflows/release.yml) (Tauri macOS build + GitHub Release draft). It does **not** deploy to Appwrite by itself; Appwrite deploys when your **connected repo** receives the push and auto deploy is enabled.
+`npm run release` / `npm run release:patch` etc. bump the version, push `main`, and push a `v*` tag. That triggers [.github/workflows/release.yml](.github/workflows/release.yml) for the Tauri macOS build + GitHub Release draft. Appwrite deployment is handled separately by the scheduled workflow unless you also enable Appwrite's Git integration.
 
 ## Troubleshooting
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -4,9 +4,13 @@ This guide explains how to deploy Mermalaid to Appwrite Sites.
 
 ## Prerequisites
 
-- An Appwrite account and project
-- Git repository connected to Appwrite (recommended — this is how deploys run)
+- An Appwrite account, project, and Site
 - Node.js 18+ (for local testing)
+- GitHub repository secrets for scheduled deploys:
+  - `APPWRITE_ENDPOINT` — regional endpoint such as `https://<REGION>.cloud.appwrite.io/v1`
+  - `APPWRITE_PROJECT_ID`
+  - `APPWRITE_API_KEY` — API key with permission to create and read site deployments
+  - `APPWRITE_SITE_ID`
 
 ## Build Configuration
 
@@ -85,14 +89,22 @@ VITE_ENABLE_AI_FIXER=true
 - For security, never commit `.env` files with actual API keys
 - Use `env.example` as a template (without sensitive data)
 
-### GitHub (recommended)
+### GitHub Actions scheduled deploy
 
-Deploys are expected to run **inside Appwrite** after you connect the repo — not via GitHub Actions in this repository.
+`.github/workflows/keep-appwrite-active.yml` deploys the app to Appwrite Sites every 5 days:
 
-1. **Repository provider**: Connect GitHub (or GitLab, etc.)
-2. **Repository**: Select this project’s repository
-3. **Production branch**: `main` (or your default branch)
-4. **Auto deploy**: Enable so pushes to that branch start a build on Appwrite’s builders (`npm install` → `npm run build` → serve `dist`)
+1. Checks out the repo
+2. Runs `npm ci`
+3. Runs `npm run build`
+4. Installs and configures the Appwrite CLI
+5. Uploads `dist` as a site deployment with `--activate true`
+6. Polls Appwrite until the deployment reports `ready`
+
+You can also run the workflow manually from the GitHub Actions tab.
+
+### GitHub / VCS integration (optional)
+
+You can still connect the repository in Appwrite Console and enable Appwrite's own auto deploy for pushes to `main`, but the scheduled GitHub Actions workflow is the recurring deployment used to keep the site active.
 
 ### Custom Domain (Optional)
 
@@ -114,11 +126,11 @@ The preview server will serve the built files from the `dist` directory, allowin
 
 ## How deployment runs
 
-1. **Git integration (default path)** — Connect GitHub under your site in the Appwrite Console (see **GitHub** above). Pushes to the production branch trigger builds on Appwrite. Check the site’s **Deployments** tab in Appwrite.
+1. **Scheduled GitHub Actions workflow** — Every 5 days, GitHub Actions builds `dist`, uploads it with `appwrite sites create-deployment`, activates the deployment, and waits for Appwrite to report `ready`.
 
-2. **Console-only** — You can also deploy from the console (branch picker or manual `.tar.gz` upload), using the same build settings as above.
+2. **Git integration** — If configured in Appwrite Console, pushes to the production branch can also start Appwrite-hosted builds.
 
-This repo does **not** use GitHub Actions for Appwrite deploys. See [.github/workflows/README.md](../.github/workflows/README.md) for workflows that *do* run on GitHub (e.g. Tauri release).
+3. **Console-only** — You can also deploy from the console (branch picker or manual `.tar.gz` upload), using the same build settings as above.
 
 ## Troubleshooting
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Replace the Appwrite health ping with a scheduled Appwrite Sites deployment.
- Build the Vite app, upload `dist` through the Appwrite CLI, activate the deployment, and poll until it is ready.
- Document required Appwrite GitHub secrets and the scheduled deployment flow.

## Testing
- `npm ci && npm run build`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/keep-appwrite-active.yml`
- `jq --version && npx --yes appwrite-cli@latest sites create-deployment --help && npx --yes appwrite-cli@latest sites get-deployment --help && git status --short`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba6901e3-168b-4002-a3de-b37b539ed2c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba6901e3-168b-4002-a3de-b37b539ed2c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

