### PR TITLE
Fix Appwrite deployment ID parsing

### DIFF
--- a/.github/workflows/keep-appwrite-active.yml
+++ b/.github/workflows/keep-appwrite-active.yml
@@ -79,7 +79,7 @@ jobs:
             --json)"
 
           echo "${DEPLOYMENT_JSON}"
-          DEPLOYMENT_ID="$(printf '%s' "${DEPLOYMENT_JSON}" | jq -r '.$id // empty')"
+          DEPLOYMENT_ID="$(printf '%s' "${DEPLOYMENT_JSON}" | jq -r '.["$id"] // empty')"
           if [ -z "${DEPLOYMENT_ID}" ]; then
             echo "::error::Appwrite did not return a deployment ID."
             exit 1


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Fix jq parsing for Appwrite deployment IDs by reading the literal `"$id"` JSON key with bracket notation.

## Testing
- `printf '%s\n' '{"$id":"6a07df8fb8b589570e29","status":"waiting"}' | jq -r '.["$id"] // empty'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/keep-appwrite-active.yml`
- `gh pr checks 81 --json name,bucket,state,workflow,link`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ba6901e3-168b-4002-a3de-b37b539ed2c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ba6901e3-168b-4002-a3de-b37b539ed2c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

