### PR TITLE
feat(editor): draggable divider to resize editor/preview panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Mermalaid includes the features teams usually pay for, while staying free to use
 
 - **Monaco Editor** - Write Mermaid with robust syntax highlighting
 - **Live Preview** - See updates in real time with smooth debounced rendering (500ms)
+- **Resizable Panels** - Drag the divider to set the editor width; your layout is saved across sessions
 - **Visual Editor** - Drag and connect flowchart nodes, then sync changes back to code
 - **Real-time Syntax Validation** - Catch errors early and fix faster
 - **Auto-save** - Keep work in local storage so progress is not lost

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,8 +8,10 @@ import { useTheme } from './hooks/useTheme'
 import { useUpdateCheck } from './hooks/useUpdateCheck'
 import { useMountEffect } from './hooks/useMountEffect'
 import { useToast } from './hooks/useToast'
+import { useEditorWidth, clampEditorWidth, viewportWidth } from './hooks/useEditorWidth'
 import Editor from './components/Editor'
 import Preview from './components/Preview'
+import PanelDivider from './components/PanelDivider'
 import Toolbar, { type ToolbarRef } from './components/Toolbar'
 import LandingPage from './components/LandingPage'
 import UpdateAvailableBanner from './components/UpdateAvailableBanner'
@@ -152,9 +154,12 @@ function EditorView({ pendingRelease, onDismissPendingRelease }: ReleaseBannerRo
   const [code, setCode] = useState('graph TD\n    A[Start] --> B{Decision}\n    B -->|Yes| C[Action 1]\n    B -->|No| D[Action 2]\n    C --> E[End]\n    D --> E')
   const [error, setError] = useState<string | null>(null)
   const [isEditorCollapsed, setIsEditorCollapsed] = useState(false)
+  const [editorWidth, setEditorWidth] = useEditorWidth()
+  const [containerWidth, setContainerWidth] = useState(viewportWidth)
   const [mobileWorkspacePanel, setMobileWorkspacePanel] = useState<MobileWorkspacePanel>('preview')
   const [selectedBlockIndex, setSelectedBlockIndex] = useState(0)
   const documentPathRef = useRef<string | null>(null)
+  const appContentRef = useRef<HTMLDivElement>(null)
   const toolbarRef = useRef<ToolbarRef>(null)
 
   // Compute mermaid blocks from the code
@@ -172,6 +177,19 @@ function EditorView({ pendingRelease, onDismissPendingRelease }: ReleaseBannerRo
       setSelectedBlockIndex(0)
     }
   }, [mermaidBlocks.length])
+
+  // Track the live width of the split row so we can clamp the applied editor width without
+  // ever mutating the user's saved preference (they keep their wide layout after a shrink).
+  useMountEffect(() => {
+    const el = appContentRef.current
+    if (!el || typeof ResizeObserver === 'undefined') return
+    const observer = new ResizeObserver((entries) => {
+      const measured = entries[0]?.contentRect.width
+      if (measured && measured > 0) setContainerWidth(measured)
+    })
+    observer.observe(el)
+    return () => observer.disconnect()
+  })
 
   useMountEffect(() => {
     try { localStorage.setItem('mermalaid-has-used-editor', '1') } catch {}
@@ -327,6 +345,8 @@ function EditorView({ pendingRelease, onDismissPendingRelease }: ReleaseBannerRo
 
   const showEditorPanel = !isSmartphoneLayout || mobileWorkspacePanel === 'editor'
   const showPreviewPanel = !isSmartphoneLayout || mobileWorkspacePanel === 'preview'
+  // Applied width is the saved preference clamped to the current window; the saved value is untouched.
+  const appliedEditorWidth = clampEditorWidth(editorWidth, containerWidth)
 
   return (
     <div
@@ -352,7 +372,7 @@ function EditorView({ pendingRelease, onDismissPendingRelease }: ReleaseBannerRo
         documentPathRef={documentPathRef}
         isMobile={isSmartphoneLayout}
       />
-      <div className="app-content">
+      <div className="app-content" ref={appContentRef}>
         {showEditorPanel && (
           <Editor
             code={code}
@@ -364,6 +384,14 @@ function EditorView({ pendingRelease, onDismissPendingRelease }: ReleaseBannerRo
             isCollapsed={isSmartphoneLayout ? false : isEditorCollapsed}
             onToggleCollapsed={() => setIsEditorCollapsed((collapsed) => !collapsed)}
             isMobile={isSmartphoneLayout}
+            width={appliedEditorWidth}
+          />
+        )}
+        {!isSmartphoneLayout && !isEditorCollapsed && (
+          <PanelDivider
+            width={appliedEditorWidth}
+            onWidthChange={setEditorWidth}
+            containerWidth={containerWidth}
           />
         )}
         {showPreviewPanel && (

--- a/src/components/Editor.tsx
+++ b/src/components/Editor.tsx
@@ -88,6 +88,8 @@ interface EditorProps {
   isCollapsed: boolean
   onToggleCollapsed: () => void
   isMobile?: boolean
+  /** Desktop split-view width in px (GitHub #91). Ignored on mobile and while collapsed. */
+  width?: number
 }
 
 function CollapseEditorIcon() {
@@ -115,6 +117,7 @@ export default function Editor({
   mermaidBlocks, selectedBlockIndex, setSelectedBlockIndex,
   isCollapsed, onToggleCollapsed,
   isMobile = false,
+  width,
 }: EditorProps) {
   const { mermaidTheme } = useTheme()
   const debounceTimer = useRef<NodeJS.Timeout>()
@@ -310,8 +313,18 @@ export default function Editor({
     return () => disposable.dispose()
   }, [mermaidBlocks, selectedBlockIndex, setSelectedBlockIndex, editorReady])
 
+  // Fixed basis drives the resizable split; the preview pane (flex: 1) fills the rest.
+  // Collapsed/mobile fall back to their CSS-class layout, so leave the style off then.
+  const panelStyle: React.CSSProperties | undefined =
+    !isMobile && !isCollapsed && typeof width === 'number'
+      ? { flex: `0 0 ${width}px` }
+      : undefined
+
   return (
-    <div className={`editor-container ${isCollapsed ? 'collapsed' : ''} ${isMobile ? 'editor-container-mobile' : ''}`}>
+    <div
+      className={`editor-container ${isCollapsed ? 'collapsed' : ''} ${isMobile ? 'editor-container-mobile' : ''}`}
+      style={panelStyle}
+    >
       <div className="editor-header">
         {!isCollapsed && <span>Editor</span>}
         <div className="editor-header-controls">

--- a/src/components/PanelDivider.css
+++ b/src/components/PanelDivider.css
@@ -1,0 +1,41 @@
+/* Draggable editor/preview separator (GitHub #91). Sits in the .app-content flex row. */
+.panel-divider {
+  flex: 0 0 6px;
+  align-self: stretch;
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  cursor: col-resize;
+  /* Keep touch drags from scrolling the page while resizing. */
+  touch-action: none;
+  background-color: transparent;
+  transition: background-color 0.15s ease;
+}
+
+.panel-divider:hover,
+.panel-divider:focus-visible {
+  outline: none;
+  background-color: color-mix(in srgb, var(--app-accent) 18%, transparent);
+}
+
+/* Center grip line — the visible affordance that this edge is draggable. */
+.panel-divider-handle {
+  width: 2px;
+  height: 28px;
+  border-radius: 999px;
+  background-color: var(--app-border);
+  transition: background-color 0.15s ease, height 0.15s ease;
+}
+
+.panel-divider:hover .panel-divider-handle,
+.panel-divider:focus-visible .panel-divider-handle {
+  height: 40px;
+  background-color: var(--app-accent);
+}
+
+/* While dragging, keep the resize cursor everywhere and stop text selection. */
+body.is-resizing-panels {
+  cursor: col-resize;
+  user-select: none;
+}

--- a/src/components/PanelDivider.tsx
+++ b/src/components/PanelDivider.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useRef } from 'react'
+import {
+  MIN_EDITOR_WIDTH_PX,
+  clampEditorWidth,
+  getMaxEditorWidth,
+} from '../hooks/useEditorWidth'
+import './PanelDivider.css'
+
+interface PanelDividerProps {
+  /** Current applied editor width in px — where the divider sits and where drags start. */
+  width: number
+  onWidthChange: (width: number) => void
+  /** Live width of the `.app-content` row, used to clamp so the preview stays usable. */
+  containerWidth: number
+}
+
+/** Keyboard nudge per arrow-key press. */
+const KEYBOARD_STEP_PX = 24
+
+/**
+ * Draggable separator that sets the editor panel width (GitHub #91). Desktop-only;
+ * the caller omits it on the stacked smartphone layout and while the editor is collapsed.
+ */
+export default function PanelDivider({ width, onWidthChange, containerWidth }: PanelDividerProps) {
+  const dragRef = useRef<{ pointerId: number; startX: number; startWidth: number } | null>(null)
+
+  // If the divider unmounts mid-drag (e.g. a tablet rotates into the stacked mobile layout),
+  // endDrag never fires — make sure the global resize cursor / text-selection lock is cleared.
+  useEffect(() => () => document.body.classList.remove('is-resizing-panels'), [])
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (e.button !== 0) return
+    e.preventDefault()
+    dragRef.current = { pointerId: e.pointerId, startX: e.clientX, startWidth: width }
+    e.currentTarget.setPointerCapture(e.pointerId)
+    document.body.classList.add('is-resizing-panels')
+  }
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current
+    if (!drag || drag.pointerId !== e.pointerId) return
+    const nextWidth = drag.startWidth + (e.clientX - drag.startX)
+    onWidthChange(clampEditorWidth(nextWidth, containerWidth))
+  }
+
+  const endDrag = (e: React.PointerEvent<HTMLDivElement>) => {
+    const drag = dragRef.current
+    if (!drag || drag.pointerId !== e.pointerId) return
+    dragRef.current = null
+    if (e.currentTarget.hasPointerCapture(e.pointerId)) {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    }
+    document.body.classList.remove('is-resizing-panels')
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    switch (e.key) {
+      case 'ArrowLeft':
+        e.preventDefault()
+        onWidthChange(clampEditorWidth(width - KEYBOARD_STEP_PX, containerWidth))
+        break
+      case 'ArrowRight':
+        e.preventDefault()
+        onWidthChange(clampEditorWidth(width + KEYBOARD_STEP_PX, containerWidth))
+        break
+      case 'Home':
+        e.preventDefault()
+        onWidthChange(clampEditorWidth(MIN_EDITOR_WIDTH_PX, containerWidth))
+        break
+      case 'End':
+        e.preventDefault()
+        onWidthChange(getMaxEditorWidth(containerWidth))
+        break
+    }
+  }
+
+  return (
+    <div
+      className="panel-divider"
+      role="separator"
+      aria-orientation="vertical"
+      aria-label="Resize editor and preview panels"
+      aria-valuenow={Math.round(width)}
+      aria-valuemin={MIN_EDITOR_WIDTH_PX}
+      aria-valuemax={Math.round(getMaxEditorWidth(containerWidth))}
+      tabIndex={0}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerCancel={endDrag}
+      onKeyDown={handleKeyDown}
+    >
+      <span className="panel-divider-handle" aria-hidden="true" />
+    </div>
+  )
+}

--- a/src/hooks/useEditorWidth.test.ts
+++ b/src/hooks/useEditorWidth.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import {
+  MIN_EDITOR_WIDTH_PX,
+  MIN_PREVIEW_WIDTH_PX,
+  clampEditorWidth,
+  getMaxEditorWidth,
+  useEditorWidth,
+} from './useEditorWidth'
+
+const STORAGE_KEY = 'mermalaid-editor-width'
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    configurable: true,
+    writable: true,
+    value: width,
+  })
+}
+
+describe('editor width bounds', () => {
+  it('leaves room for the preview pane', () => {
+    expect(getMaxEditorWidth(1280)).toBe(1280 - MIN_PREVIEW_WIDTH_PX)
+  })
+
+  it('never lets the max drop below the editor minimum', () => {
+    // A window too small for both minimums pins the max at the editor minimum.
+    expect(getMaxEditorWidth(MIN_EDITOR_WIDTH_PX)).toBe(MIN_EDITOR_WIDTH_PX)
+  })
+
+  it('clamps values into [min, max]', () => {
+    expect(clampEditorWidth(600, 1280)).toBe(600)
+    expect(clampEditorWidth(50, 1280)).toBe(MIN_EDITOR_WIDTH_PX)
+    expect(clampEditorWidth(5000, 1280)).toBe(getMaxEditorWidth(1280))
+  })
+})
+
+describe('useEditorWidth', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    setViewportWidth(1280)
+  })
+
+  it('defaults to half the viewport when nothing is stored', () => {
+    const { result } = renderHook(() => useEditorWidth())
+    expect(result.current[0]).toBe(640)
+  })
+
+  it('restores a stored width verbatim', () => {
+    localStorage.setItem(STORAGE_KEY, '450')
+    const { result } = renderHook(() => useEditorWidth())
+    expect(result.current[0]).toBe(450)
+  })
+
+  it('keeps an oversized stored width unclamped (consumers clamp for display)', () => {
+    // The saved preference is preserved so a wide layout returns when the window grows back.
+    localStorage.setItem(STORAGE_KEY, '5000')
+    const { result } = renderHook(() => useEditorWidth())
+    expect(result.current[0]).toBe(5000)
+  })
+
+  it('falls back to the default for a non-numeric or non-positive stored value', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-a-number')
+    expect(renderHook(() => useEditorWidth()).result.current[0]).toBe(640)
+
+    localStorage.setItem(STORAGE_KEY, '-100')
+    expect(renderHook(() => useEditorWidth()).result.current[0]).toBe(640)
+  })
+
+  it('persists width changes to localStorage, debounced', () => {
+    vi.useFakeTimers()
+    try {
+      const { result } = renderHook(() => useEditorWidth())
+      act(() => {
+        result.current[1](720)
+      })
+      // The write is debounced, so nothing has hit storage yet.
+      expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+      act(() => {
+        vi.runAllTimers()
+      })
+      expect(localStorage.getItem(STORAGE_KEY)).toBe('720')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/hooks/useEditorWidth.ts
+++ b/src/hooks/useEditorWidth.ts
@@ -1,0 +1,63 @@
+import { useEffect, useState } from 'react'
+
+/** Persisted editor-panel width for the desktop split view (GitHub #91). Preview fills the rest. */
+const STORAGE_KEY = 'mermalaid-editor-width'
+
+/** Delay before a width change is written to storage — avoids a disk write on every drag frame. */
+const PERSIST_DEBOUNCE_MS = 200
+
+/** Resize bounds — keep both the editor and preview panes usable at any window size. */
+export const MIN_EDITOR_WIDTH_PX = 280
+export const MIN_PREVIEW_WIDTH_PX = 320
+
+/** A sane desktop width to fall back on when the real viewport isn't measurable yet. */
+const FALLBACK_VIEWPORT_WIDTH_PX = 1280
+
+export function viewportWidth(): number {
+  const w = typeof window !== 'undefined' ? window.innerWidth : 0
+  return w > 0 ? w : FALLBACK_VIEWPORT_WIDTH_PX
+}
+
+/** Largest editor width that still leaves {@link MIN_PREVIEW_WIDTH_PX} for the preview pane. */
+export function getMaxEditorWidth(containerWidth: number): number {
+  return Math.max(MIN_EDITOR_WIDTH_PX, containerWidth - MIN_PREVIEW_WIDTH_PX)
+}
+
+export function clampEditorWidth(width: number, containerWidth: number): number {
+  return Math.min(Math.max(width, MIN_EDITOR_WIDTH_PX), getMaxEditorWidth(containerWidth))
+}
+
+function readStoredWidth(): number | null {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY)
+    if (!saved) return null
+    const parsed = Number.parseInt(saved, 10)
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * The user's preferred editor width in pixels, persisted to localStorage.
+ *
+ * This is the *desired* width and is deliberately never clamped here — consumers clamp it to
+ * the live container for display, so a wide layout is restored when the window grows back rather
+ * than being permanently shrunk. Defaults to half the viewport to match the previous 50/50 split.
+ */
+export function useEditorWidth() {
+  const [width, setWidth] = useState<number>(
+    () => readStoredWidth() ?? Math.round(viewportWidth() / 2),
+  )
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      try {
+        localStorage.setItem(STORAGE_KEY, String(Math.round(width)))
+      } catch {}
+    }, PERSIST_DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [width])
+
+  return [width, setWidth] as const
+}


### PR DESCRIPTION
## What & why

Adds a draggable divider between the editor and preview panels so the editor width can be freely adjusted, then remembers it. This is the secondary ask in #91 — *"I can't seem to adjust the width of the editor panel"* — which the reporter called out as a big reason they preferred another editor.

Before, the editor could only be collapsed to a rail (all-or-nothing); now you can set any width in between.

## What changed

- **`src/hooks/useEditorWidth.ts`** — persists the width to `localStorage` (`mermalaid-editor-width`, following the `mermalaid-*` convention). Exposes clamp helpers (`clampEditorWidth`, `getMaxEditorWidth`) with a `280px` editor min / `320px` preview min. The write is debounced (200ms) so a drag doesn't hit disk every frame — same pattern as the existing `mermalaid-draft` autosave.
- **`src/components/PanelDivider.tsx` / `.css`** — the splitter. Pointer-capture drag plus full keyboard support (`role="separator"`, `aria-valuenow/min/max`, arrows + Home/End). Themed with the existing `--app-border` / `--app-accent` CSS variables.
- **`src/App.tsx`** — tracks the live container width via `ResizeObserver` and renders the divider only on desktop when the editor is expanded.
- **`src/components/Editor.tsx`** — applies the width as `flex: 0 0 <w>px`, only on desktop-expanded (collapse/mobile keep their existing CSS-class layout).

### Design note: desired vs. applied width
The **saved** value is the user's *desired* width and is only ever changed by the user dragging. The **applied** width is that value clamped to the live container. So shrinking the window (or crossing into mobile) clamps the display **without overwriting the preference** — a 960px layout returns to 960px when the window grows back, instead of being permanently squished.

## Acceptance

- ✅ Desktop: drag the divider (or focus it + arrow keys) to resize
- ✅ Width persists across reloads
- ✅ Min/max clamp keeps both panes usable
- ✅ Mobile single-panel layout unaffected (no divider, editor full-width)
- ✅ Existing collapse toggle still works and preserves the saved width

## Testing

- `npm test` — 101 pass (8 new unit tests for the clamp bounds, persistence, and edge cases)
- `tsc` clean, `npm run build` clean
- Verified in-browser with `npm run dev`: real pointer-drag + keyboard resize, persistence across reload, min/max clamps, collapse/expand round-trip, mobile layout (`innerWidth 390` → no divider, single panel), and window shrink→grow preserving the saved width. No console errors.

## Scope note

#91's *primary* request — live-reloading files edited in an **external** editor — is a separate, larger piece of work and is **not** included here. This PR delivers the panel-resize ask, so it's marked "Addresses" rather than "Closes" #91.
