### PR TITLE
Add Windows NSIS installer to releases

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,10 +12,15 @@ Automatically creates GitHub releases and builds Tauri applications for macOS an
 
 **Trigger:** Push tags matching `v*` (e.g., `v1.0.0`)
 
+**Jobs:**
+
+- `prepare-release` - fails if a published release already exists for the tag, deletes a stale draft, then creates one draft release and passes its id to the build jobs
+- `build-tauri` - matrix over macOS and Windows; each runner builds with tauri-action and uploads its installer to that draft
+
 **Output:**
 
 - GitHub Release draft
-- macOS `.app` bundle and `.dmg` installer
+- macOS `.app` bundle and `.dmg` installer (universal binary)
 - Windows x64 NSIS `.exe` installer
 
 **Secrets:** Uses the default `GITHUB_TOKEN` only (no extra repository secrets required for this workflow).

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,7 +8,7 @@ This directory contains GitHub Actions workflows for automating tasks in this re
 
 ### `release.yml`
 
-Automatically creates GitHub releases and builds Tauri macOS applications when version tags are pushed.
+Automatically creates GitHub releases and builds Tauri applications for macOS and Windows when version tags are pushed.
 
 **Trigger:** Push tags matching `v*` (e.g., `v1.0.0`)
 
@@ -16,6 +16,7 @@ Automatically creates GitHub releases and builds Tauri macOS applications when v
 
 - GitHub Release draft
 - macOS `.app` bundle and `.dmg` installer
+- Windows x64 NSIS `.exe` installer
 
 **Secrets:** Uses the default `GITHUB_TOKEN` only (no extra repository secrets required for this workflow).
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,10 +6,14 @@ on:
       - 'v*'
 
 jobs:
+  # Runs once per tag so that the two platform builds share a single draft
+  # release instead of racing tauri-action's find-or-create logic.
   prepare-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      release_id: ${{ steps.create.outputs.release_id }}
     steps:
       - name: Check for existing release
         env:
@@ -21,7 +25,7 @@ jobs:
           if gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
             RELEASE_STATE=$(gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
             if [ "$RELEASE_STATE" = "true" ]; then
-              echo "Draft release already exists. Deleting it so tauri-action can recreate it."
+              echo "Draft release already exists. Deleting it so a fresh one can be created."
               gh release delete "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --yes
             else
               echo "ERROR: Published release already exists for tag $TAG_NAME"
@@ -31,6 +35,24 @@ jobs:
           else
             echo "No existing release found."
           fi
+
+      - name: Create draft release
+        id: create
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          RELEASE_ID=$(gh api -X POST "repos/$GITHUB_REPOSITORY/releases" \
+            -f tag_name="$TAG_NAME" \
+            -f name="Release $TAG_NAME" \
+            -F draft=true \
+            --jq .id) || RELEASE_ID=""
+          if [ -z "$RELEASE_ID" ] || [ "$RELEASE_ID" = "null" ]; then
+            echo "ERROR: Failed to create draft release for $TAG_NAME"
+            exit 1
+          fi
+          echo "Created draft release $RELEASE_ID for $TAG_NAME"
+          echo "release_id=$RELEASE_ID" >> "$GITHUB_OUTPUT"
 
   build-tauri:
     needs: prepare-release
@@ -43,7 +65,7 @@ jobs:
           # Universal binary: Intel (x86_64) + Apple Silicon (aarch64) in one DMG
           - platform: 'macos-latest'
             args: '--target universal-apple-darwin'
-          # 64-bit Windows NSIS installer
+          # 64-bit Windows NSIS installer (explicitly skips the MSI bundle)
           - platform: 'windows-latest'
             args: '--bundles nsis'
 
@@ -82,9 +104,11 @@ jobs:
           RUST_BACKTRACE: 1
         with:
           projectPath: ./
+          # Upload to the draft created by prepare-release. tagName is kept so
+          # tauri-action still fails loudly (instead of silently skipping the
+          # upload) if the release id is ever missing.
+          releaseId: ${{ needs.prepare-release.outputs.release_id }}
           tagName: ${{ github.ref }}
-          releaseName: Release ${{ github.ref_name }}
-          releaseDraft: true
           args: ${{ matrix.args }}
 
       - name: Verify DMG was created
@@ -109,8 +133,7 @@ jobs:
         run: |
           $installer = Get-ChildItem src-tauri/target -Recurse -Filter '*-setup.exe' | Select-Object -First 1
           if (-not $installer) {
-            Write-Error 'NSIS installer not found under src-tauri/target'
-            exit 1
+            throw 'NSIS installer not found under src-tauri/target'
           }
           Write-Host "NSIS installer found: $($installer.FullName)"
           Get-Item $installer.FullName | Format-List FullName, Length, LastWriteTime

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,34 @@ on:
       - 'v*'
 
 jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Check for existing release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG_NAME=${GITHUB_REF#refs/tags/}
+          echo "Checking for existing release: $TAG_NAME"
+
+          if gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            RELEASE_STATE=$(gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
+            if [ "$RELEASE_STATE" = "true" ]; then
+              echo "Draft release already exists. Deleting it so tauri-action can recreate it."
+              gh release delete "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --yes
+            else
+              echo "ERROR: Published release already exists for tag $TAG_NAME"
+              echo "Delete the existing release or use a different tag."
+              exit 1
+            fi
+          else
+            echo "No existing release found."
+          fi
+
   build-tauri:
+    needs: prepare-release
     permissions:
       contents: write
     strategy:
@@ -16,6 +43,9 @@ jobs:
           # Universal binary: Intel (x86_64) + Apple Silicon (aarch64) in one DMG
           - platform: 'macos-latest'
             args: '--target universal-apple-darwin'
+          # 64-bit Windows NSIS installer
+          - platform: 'windows-latest'
+            args: '--bundles nsis'
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -30,6 +60,7 @@ jobs:
         uses: dtolnay/rust-toolchain@stable
 
       - name: Install Rust targets for universal macOS build
+        if: runner.os == 'macOS'
         run: rustup target add aarch64-apple-darwin x86_64-apple-darwin
 
       - name: Install frontend dependencies
@@ -39,32 +70,11 @@ jobs:
         run: npm run build
 
       - name: Verify DMG tools
+        if: runner.os == 'macOS'
         run: |
           echo "Checking DMG creation prerequisites..."
           which hdiutil && echo "✓ hdiutil found" || echo "✗ hdiutil not found"
           xcode-select -p && echo "✓ Xcode Command Line Tools found" || echo "✗ Xcode Command Line Tools not found"
-
-      - name: Check for existing release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          TAG_NAME=${GITHUB_REF#refs/tags/}
-          echo "Checking for existing release: $TAG_NAME"
-          
-          if gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" &>/dev/null; then
-            RELEASE_STATE=$(gh release view "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --json isDraft --jq .isDraft)
-            if [ "$RELEASE_STATE" == "true" ]; then
-              echo "⚠️  Draft release already exists. Deleting it so tauri-action can create a new one..."
-              gh release delete "$TAG_NAME" --repo "$GITHUB_REPOSITORY" --yes || true
-            else
-              echo "❌ ERROR: Published release already exists for tag $TAG_NAME"
-              echo "Published releases are immutable and cannot be modified."
-              echo "Please delete the existing release or use a different tag."
-              exit 1
-            fi
-          else
-            echo "✓ No existing release found. tauri-action will create a new draft release."
-          fi
 
       - uses: tauri-apps/tauri-action@v0
         env:
@@ -78,6 +88,7 @@ jobs:
           args: ${{ matrix.args }}
 
       - name: Verify DMG was created
+        if: runner.os == 'macOS'
         run: |
           echo "Checking for DMG file..."
           # universal-apple-darwin outputs under target/universal-apple-darwin/release/bundle/
@@ -91,3 +102,15 @@ jobs:
             echo "✅ DMG file found: $DMG_PATH"
             ls -lh "$DMG_PATH"
           fi
+
+      - name: Verify NSIS installer was created
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $installer = Get-ChildItem src-tauri/target -Recurse -Filter '*-setup.exe' | Select-Object -First 1
+          if (-not $installer) {
+            Write-Error 'NSIS installer not found under src-tauri/target'
+            exit 1
+          }
+          Write-Host "NSIS installer found: $($installer.FullName)"
+          Get-Item $installer.FullName | Format-List FullName, Length, LastWriteTime

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you need a **free Mermaid editor** without limits, subscriptions, or account 
 - ✅ **Unlimited Diagrams** - Create as many Mermaid charts as you need
 - ✅ **Professional Features** - Live preview, visual editor, syntax checks, flexible export, and private share links
 - ✅ **Privacy-First** - Your diagrams stay local; no cloud sync required
-- ✅ **Web & Desktop** - Use it in your browser or as a native macOS app
+- ✅ **Web & Desktop** - Use it in your browser or as a native macOS or Windows app
 
 ## 🚀 Quick Start - Create Your First Mermaid Diagram
 
@@ -81,7 +81,7 @@ Create diagrams across the full Mermaid ecosystem:
 ### Cross-Platform Support
 
 - **Web Application** - Works in any modern browser
-- **Native macOS App** - Lightweight desktop application
+- **Native Desktop App** - Lightweight application for macOS and Windows
 - **Vercel Hosting** - Static Vite deployment with preview and production URLs
 
 ## 💻 Technical Excellence
@@ -102,7 +102,7 @@ Mermalaid uses Tauri instead of Electron for a superior experience:
 - ⚡ **Better performance** using system webview instead of bundled Chromium
 - 🔒 **Enhanced security** with Rust backend
 - 💰 **Lower memory usage** - Runs efficiently on any machine
-- 🎯 **Better native integration** - Feels like a real macOS app
+- 🎯 **Better native integration** - Feels like a real native app
 
 ## 📚 Use Cases - When to Use Mermalaid
 
@@ -159,7 +159,7 @@ classDiagram
 
 - Node.js 18+
 - Rust (Tauri will install automatically if not present)
-- macOS (for building macOS apps)
+- macOS (to build the macOS app) or Windows 10/11 with the Microsoft C++ Build Tools (to build the Windows installer)
 
 ### Running in Development
 
@@ -195,7 +195,11 @@ The built app will be in `src-tauri/target/release/bundle/`:
 
 ### Installing the Desktop App
 
-**Important:** The app is currently unsigned (not code-signed). macOS may show a "damaged" warning when you first open it.
+**Important:** The app is currently unsigned (not code-signed), so macOS warns you the first time you open the app and Windows warns you when you run the installer.
+
+#### macOS
+
+macOS may report the app as "damaged" when you first open it.
 
 **Recommended Installation Method:**
 ```bash
@@ -215,6 +219,10 @@ open /Applications/Mermalaid.app
 3. Click **"Open Anyway"** next to the Mermalaid warning
 4. Click **"Open"** in the confirmation dialog
 
+#### Windows
+
+The installer is unsigned, so SmartScreen shows "Windows protected your PC" when you run the `.exe`. Click **More info**, then **Run anyway** to continue with the installation.
+
 ## ⌨️ Keyboard Shortcuts
 
 - `⌘N` (Mac) / `Ctrl+N` (Windows/Linux): New diagram
@@ -228,7 +236,7 @@ Mermalaid is source-available and welcomes contributions! See [CONTRIBUTING.md](
 Areas where contributions are especially welcome:
 - Additional Mermaid diagram types
 - Export formats (PDF, etc.)
-- Platform support (Windows, Linux)
+- Platform support (Linux)
 - Performance improvements
 - Documentation and examples
 
@@ -274,7 +282,7 @@ Because this license includes a non-commercial clause, Mermalaid is source-avail
 | **Privacy** | ✅ Local storage only | ❌ Cloud sync required |
 | **Export Options** | ✅ SVG, PNG, ASCII | ✅/❌ Varies |
 | **Syntax Validation** | ✅ Real-time | ✅/❌ Varies |
-| **Desktop App** | ✅ Native macOS | ❌ Often web-only |
+| **Desktop App** | ✅ Native macOS and Windows | ❌ Often web-only |
 | **Visual Editor** | ✅ Yes (flowcharts) | ❌ Usually code-only |
 
 ---

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ If you need a **free Mermaid editor** without limits, subscriptions, or account 
 
 Visit [Mermalaid](https://mermalaid.com) to start creating Mermaid diagrams instantly in your browser—no installation needed.
 
-### Download Desktop App (macOS)
+### Download Desktop App (macOS and Windows)
 
 1. Download the latest release from [GitHub Releases](https://github.com/highvoltag3/mermalaid/releases)
-2. Install the `.dmg` file
+2. Install the `.dmg` file on macOS or the x64 `.exe` setup file on Windows
 3. Start creating unlimited free Mermaid diagrams
 4. 🏴‍☠️ IMPORTANT: Follow this step: [Installing the Desktop App](#installing-the-desktop-app).
 
@@ -185,13 +185,13 @@ This will:
 # Build web assets
 npm run build
 
-# Build macOS desktop app
+# Build the desktop app for the current platform
 npm run tauri:build
 ```
 
 The built app will be in `src-tauri/target/release/bundle/`:
-- `.app` file for macOS
-- `.dmg` installer
+- macOS: `.app` bundle and `.dmg` installer
+- Windows: x64 NSIS `.exe` installer
 
 ### Installing the Desktop App
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -96,7 +96,7 @@ Commit the updated PNGs after regenerating.
 
 ### Desktop releases are separate from the web app
 
-`npm run release` / `npm run release:patch` etc. bump the version, push `main`, and push a `v*` tag. That triggers [.github/workflows/release.yml](../.github/workflows/release.yml) for the Tauri macOS build and GitHub Release draft. Web deployment is handled separately by Vercel.
+`npm run release` / `npm run release:patch` etc. bump the version, push `main`, and push a `v*` tag. That triggers [.github/workflows/release.yml](../.github/workflows/release.yml), which creates the GitHub Release draft and builds the Tauri macOS and Windows installers. Web deployment is handled separately by Vercel.
 
 ## Troubleshooting
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -36,25 +36,35 @@ fn enqueue_open_paths(app: &tauri::AppHandle, paths: Vec<PathBuf>) {
     let _ = app.emit("open-files", ());
 }
 
-#[cfg(any(target_os = "windows", target_os = "linux"))]
-fn collect_argv_file_paths() -> Vec<PathBuf> {
-    let mut files = Vec::new();
-
-    for maybe_file in std::env::args().skip(1) {
-        if maybe_file.starts_with('-') {
-            continue;
-        }
-
-        if let Ok(url) = url::Url::parse(&maybe_file) {
-            if let Ok(path) = url.to_file_path() {
-                files.push(path);
-            }
-        } else {
-            files.push(PathBuf::from(maybe_file));
-        }
+/// Interprets one command-line argument as a file to open, if it is one.
+///
+/// Windows and Linux hand associated files to the app as plain paths
+/// (`C:\Users\me\diagram.mmd`, `/home/me/diagram.mmd`), while some launchers
+/// pass `file://` URLs. A bare Windows path parses as a URL whose scheme is the
+/// drive letter (`c`), so only genuine `file:` URLs are decoded as URLs; a
+/// one-letter scheme is treated as a path and any other scheme (`https:`,
+/// `mailto:`, ...) is not a local file and is ignored.
+#[cfg(any(target_os = "windows", target_os = "linux", test))]
+fn argv_entry_to_path(arg: &str) -> Option<PathBuf> {
+    if arg.is_empty() || arg.starts_with('-') {
+        return None;
     }
 
-    files
+    match url::Url::parse(arg) {
+        Ok(url) if url.scheme() == "file" => url.to_file_path().ok(),
+        Ok(url) if url.scheme().len() == 1 => Some(PathBuf::from(arg)),
+        Ok(_) => None,
+        Err(_) => Some(PathBuf::from(arg)),
+    }
+}
+
+#[cfg(any(target_os = "windows", target_os = "linux", test))]
+#[cfg_attr(test, allow(dead_code))]
+fn collect_argv_file_paths() -> Vec<PathBuf> {
+    std::env::args()
+        .skip(1)
+        .filter_map(|arg| argv_entry_to_path(&arg))
+        .collect()
 }
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
@@ -92,4 +102,66 @@ pub fn run() {
                 }
             }
         });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::argv_entry_to_path;
+    use std::path::PathBuf;
+
+    #[test]
+    fn windows_drive_letter_path_is_kept_as_a_path() {
+        let arg = r"C:\Users\bob\diagram.mmd";
+        assert_eq!(argv_entry_to_path(arg), Some(PathBuf::from(arg)));
+    }
+
+    #[test]
+    fn windows_path_with_spaces_and_lowercase_drive_is_kept() {
+        let arg = r"d:\My Diagrams\flow chart.mmd";
+        assert_eq!(argv_entry_to_path(arg), Some(PathBuf::from(arg)));
+    }
+
+    #[test]
+    fn unc_path_is_kept_as_a_path() {
+        let arg = r"\\server\share\diagram.mmd";
+        assert_eq!(argv_entry_to_path(arg), Some(PathBuf::from(arg)));
+    }
+
+    #[test]
+    fn unix_absolute_and_relative_paths_are_kept() {
+        for arg in [
+            "/home/bob/diagram.mmd",
+            "diagram.mmd",
+            "./nested/diagram.mmd",
+        ] {
+            assert_eq!(argv_entry_to_path(arg), Some(PathBuf::from(arg)));
+        }
+    }
+
+    #[test]
+    fn file_url_is_decoded_to_a_path() {
+        #[cfg(unix)]
+        assert_eq!(
+            argv_entry_to_path("file:///tmp/diagram.mmd"),
+            Some(PathBuf::from("/tmp/diagram.mmd"))
+        );
+        #[cfg(windows)]
+        assert_eq!(
+            argv_entry_to_path("file:///C:/Users/bob/diagram.mmd"),
+            Some(PathBuf::from(r"C:\Users\bob\diagram.mmd"))
+        );
+    }
+
+    #[test]
+    fn non_file_urls_flags_and_empty_args_are_ignored() {
+        for arg in [
+            "https://example.com/diagram.mmd",
+            "mailto:someone@example.com",
+            "--flag",
+            "-v",
+            "",
+        ] {
+            assert_eq!(argv_entry_to_path(arg), None, "{arg:?}");
+        }
+    }
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -53,7 +53,8 @@
     ],
     "targets": [
       "app",
-      "dmg"
+      "dmg",
+      "nsis"
     ],
     "icon": [
       "icons/icon_16x16.png",

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,15 @@
+{
+  "bundle": {
+    "fileAssociations": [
+      {
+        "ext": [
+          "mmd"
+        ],
+        "name": "Mermaid diagram",
+        "description": "Mermaid diagram source",
+        "role": "Editor",
+        "mimeType": "text/plain"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
- add a Windows runner to the Tauri release matrix
- build and upload an x64 NSIS installer for version tags
- prepare the draft release once before parallel platform builds
- verify the generated Windows setup executable
- document Windows downloads and build artifacts

## Verification
- parsed .github/workflows/release.yml successfully as YAML
- ran 
pm run tauri:build -- --bundles nsis on Windows
- produced Mermalaid_1.7.0_x64-setup.exe successfully

The generated installer remains a GitHub Release asset rather than being committed to Git history. Download here: https://github.com/trackme518/mermalaid/releases/download/v1.7.0/Mermalaid_1.7.0_x64-setup.exe 

Verified on Windows 11 amd64.