### PR TITLE
Show primary Mermaid errors when preview fallbacks succeed (#100)

### DIFF
--- a/src/components/Preview.tsx
+++ b/src/components/Preview.tsx
@@ -1,5 +1,4 @@
 import { useEffect, useMemo, useRef, useState, type RefObject } from 'react'
-import { renderMermaid as renderBeautifulMermaid } from 'beautiful-mermaid'
 import {
   TransformComponent,
   TransformWrapper,
@@ -8,12 +7,12 @@ import {
   type ReactZoomPanPinchContentRef,
 } from 'react-zoom-pan-pinch'
 import { useTheme } from '../hooks/useTheme'
+import { useToast } from '../hooks/useToast'
 import { replaceMermaidBlock, type MermaidBlock } from '../utils/mermaidCodeBlock'
 import { getMermaidThemeOptions, isAppThemeDark } from '../utils/mermaidThemes'
 import { isEditableDiagram, parseMermaidFlowchart } from '../utils/mermaidParser'
 import { normalizeMermaidForBeautifulMermaid } from '../utils/normalizeMermaidForBeautifulMermaid'
 import {
-  mapMermaidConfigToThemeOptions,
   parseMermaidWithConfig,
   parseMermaidConfigForOfficialRenderer,
   replaceDiagramInBlock,
@@ -22,7 +21,10 @@ import {
   buildMermalaidAboutPreviewHtml,
   isMermaidAboutKeywordOnly,
 } from '../utils/mermalaidInfoText'
-import { renderOfficialMermaidPreview } from '../utils/officialMermaidPreview'
+import {
+  MermaidAboutKeywordFallback,
+  renderMermaidPreviewWithFallback,
+} from '../utils/renderMermaidPreviewWithFallback'
 import { MERMLAID_PREVIEW_DEBOUNCE_MS } from '../constants/mermalaidTiming'
 import VisualEditor from './VisualEditor'
 import './Preview.css'
@@ -204,6 +206,8 @@ export default function Preview({
   const previewRef = useRef<HTMLDivElement>(null)
   const transformRef = useRef<ReactZoomPanPinchContentRef | null>(null)
   const renderIdRef = useRef(0)
+  const { showToast } = useToast()
+  const lastFallbackToastRef = useRef<string | null>(null)
   const [isEditMode, setIsEditMode] = useState(false)
   const [diagramReady, setDiagramReady] = useState(false)
   const [previewFitTick, setPreviewFitTick] = useState(0)
@@ -268,12 +272,14 @@ export default function Preview({
           if (renderIdRef.current === currentId && container) {
             container.innerHTML = html
             setError(null)
+            lastFallbackToastRef.current = null
             setDiagramReady(true)
             setPreviewFitTick((t) => t + 1)
           }
         } catch (err) {
           const errorMsg =
             err instanceof Error ? err.message : 'Could not load Mermalaid info'
+          lastFallbackToastRef.current = null
           setError(errorMsg)
           if (renderIdRef.current === currentId && container) {
             container.innerHTML = `<div class="error-preview">${errorMsg}</div>`
@@ -290,6 +296,7 @@ export default function Preview({
         if (renderIdRef.current === currentId) {
           container.innerHTML = '<div class="empty-preview">Start typing your Mermaid diagram...</div>'
           setError(null)
+          lastFallbackToastRef.current = null
           setDiagramReady(false)
         }
         return
@@ -301,52 +308,37 @@ export default function Preview({
       }
 
       try {
-        let svg: string
-        const normalizedForCompat = normalizeMermaidForBeautifulMermaid(diagramCode)
-        try {
-          svg = await renderOfficialMermaidPreview(
-            diagramCode,
-            isAppThemeDark(mermaidTheme),
-            previewThemeOptions,
-            officialYamlConfig,
-          )
-        } catch (primaryErr) {
-          // Compatibility fallback: keep official Mermaid as the default path,
-          // but retry with legacy flowchart normalization to avoid regressions
-          // on diagrams that previously rendered in Mermalaid.
-          try {
-            if (normalizedForCompat !== diagramCode) {
-              svg = await renderOfficialMermaidPreview(
-                normalizedForCompat,
-                isAppThemeDark(mermaidTheme),
-                previewThemeOptions,
-                officialYamlConfig,
-              )
-            } else {
-              throw primaryErr
-            }
-          } catch {
-            // Last-resort legacy renderer fallback for pre-existing diagrams.
-            if (isMermaidAboutKeywordOnly(normalizedForCompat)) {
-              await applyMermalaidAboutPanel()
-              return
-            }
-            const themeOptions = yamlConfig
-              ? mapMermaidConfigToThemeOptions(yamlConfig)
-              : previewThemeOptions
-            svg = await renderBeautifulMermaid(normalizedForCompat, themeOptions)
-          }
-        }
+        const { svg, primaryError } = await renderMermaidPreviewWithFallback({
+          diagramCode,
+          isDark: isAppThemeDark(mermaidTheme),
+          previewThemeOptions,
+          officialYamlConfig,
+          yamlConfig,
+        })
         const normalizedSvg = normalizePreviewSvgDimensions(svg)
 
         if (renderIdRef.current === currentId && container) {
           container.innerHTML = normalizedSvg
-          setError(null)
+          if (primaryError) {
+            setError(primaryError)
+            if (lastFallbackToastRef.current !== primaryError) {
+              lastFallbackToastRef.current = primaryError
+              showToast(primaryError, 'error')
+            }
+          } else {
+            setError(null)
+            lastFallbackToastRef.current = null
+          }
           setDiagramReady(true)
           setPreviewFitTick((t) => t + 1)
         }
       } catch (err) {
+        if (err instanceof MermaidAboutKeywordFallback) {
+          await applyMermalaidAboutPanel()
+          return
+        }
         const errorMsg = err instanceof Error ? err.message : 'Invalid Mermaid syntax'
+        lastFallbackToastRef.current = null
         setError(errorMsg)
         if (renderIdRef.current === currentId && container) {
           container.innerHTML = `<div class="error-preview">${errorMsg}<div class="error-recovery-hint">Try creating a new diagram (New button) or opening a valid .mmd file.</div></div>`
@@ -359,10 +351,10 @@ export default function Preview({
   }, [
     code,
     setError,
+    showToast,
     isEditMode,
     canEdit,
     diagramCode,
-    codeForBeautifulMermaid,
     yamlConfig,
     mermaidTheme,
     previewThemeOptions,

--- a/src/utils/renderMermaidPreviewWithFallback.test.ts
+++ b/src/utils/renderMermaidPreviewWithFallback.test.ts
@@ -9,13 +9,11 @@ const {
   renderBeautifulMermaid,
   normalizeMermaidForBeautifulMermaid,
   isMermaidAboutKeywordOnly,
-  mapMermaidConfigToThemeOptions,
 } = vi.hoisted(() => ({
   renderOfficialMermaidPreview: vi.fn(),
   renderBeautifulMermaid: vi.fn(),
   normalizeMermaidForBeautifulMermaid: vi.fn((code: string) => code),
   isMermaidAboutKeywordOnly: vi.fn(() => false),
-  mapMermaidConfigToThemeOptions: vi.fn(() => ({ bg: '#fff', fg: '#000' })),
 }))
 
 vi.mock('./officialMermaidPreview', () => ({
@@ -33,16 +31,6 @@ vi.mock('./normalizeMermaidForBeautifulMermaid', () => ({
 vi.mock('./mermalaidInfoText', () => ({
   isMermaidAboutKeywordOnly,
 }))
-
-vi.mock('./mermaidYamlConfig', async () => {
-  const actual = await vi.importActual<typeof import('./mermaidYamlConfig')>(
-    './mermaidYamlConfig',
-  )
-  return {
-    ...actual,
-    mapMermaidConfigToThemeOptions,
-  }
-})
 
 const baseOptions = {
   diagramCode: 'flowchart TD\n  A-->B',

--- a/src/utils/renderMermaidPreviewWithFallback.test.ts
+++ b/src/utils/renderMermaidPreviewWithFallback.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  MermaidAboutKeywordFallback,
+  renderMermaidPreviewWithFallback,
+} from './renderMermaidPreviewWithFallback'
+
+const {
+  renderOfficialMermaidPreview,
+  renderBeautifulMermaid,
+  normalizeMermaidForBeautifulMermaid,
+  isMermaidAboutKeywordOnly,
+  mapMermaidConfigToThemeOptions,
+} = vi.hoisted(() => ({
+  renderOfficialMermaidPreview: vi.fn(),
+  renderBeautifulMermaid: vi.fn(),
+  normalizeMermaidForBeautifulMermaid: vi.fn((code: string) => code),
+  isMermaidAboutKeywordOnly: vi.fn(() => false),
+  mapMermaidConfigToThemeOptions: vi.fn(() => ({ bg: '#fff', fg: '#000' })),
+}))
+
+vi.mock('./officialMermaidPreview', () => ({
+  renderOfficialMermaidPreview,
+}))
+
+vi.mock('beautiful-mermaid', () => ({
+  renderMermaid: renderBeautifulMermaid,
+}))
+
+vi.mock('./normalizeMermaidForBeautifulMermaid', () => ({
+  normalizeMermaidForBeautifulMermaid,
+}))
+
+vi.mock('./mermalaidInfoText', () => ({
+  isMermaidAboutKeywordOnly,
+}))
+
+vi.mock('./mermaidYamlConfig', async () => {
+  const actual = await vi.importActual<typeof import('./mermaidYamlConfig')>(
+    './mermaidYamlConfig',
+  )
+  return {
+    ...actual,
+    mapMermaidConfigToThemeOptions,
+  }
+})
+
+const baseOptions = {
+  diagramCode: 'flowchart TD\n  A-->B',
+  isDark: false,
+  previewThemeOptions: { bg: '#fff', fg: '#000' },
+  officialYamlConfig: undefined,
+  yamlConfig: undefined,
+}
+
+describe('renderMermaidPreviewWithFallback', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    normalizeMermaidForBeautifulMermaid.mockImplementation((code: string) => code)
+    isMermaidAboutKeywordOnly.mockReturnValue(false)
+  })
+
+  it('returns svg with no primaryError when official render succeeds', async () => {
+    renderOfficialMermaidPreview.mockResolvedValue('<svg>ok</svg>')
+
+    const result = await renderMermaidPreviewWithFallback(baseOptions)
+
+    expect(result).toEqual({ svg: '<svg>ok</svg>', primaryError: null })
+    expect(renderBeautifulMermaid).not.toHaveBeenCalled()
+  })
+
+  it('keeps primaryError when official fails and beautiful-mermaid fallback succeeds', async () => {
+    renderOfficialMermaidPreview.mockRejectedValue(
+      new Error('Namespace and class share the same name'),
+    )
+    renderBeautifulMermaid.mockResolvedValue('<svg>fallback</svg>')
+
+    const result = await renderMermaidPreviewWithFallback({
+      ...baseOptions,
+      diagramCode: 'classDiagram\nnamespace Foo {\n  class Foo\n}',
+    })
+
+    expect(result.svg).toBe('<svg>fallback</svg>')
+    expect(result.primaryError).toBe('Namespace and class share the same name')
+  })
+
+  it('keeps primaryError when compat-normalized official render succeeds', async () => {
+    normalizeMermaidForBeautifulMermaid.mockImplementation(
+      (code: string) => `${code}\n%% normalized`,
+    )
+    renderOfficialMermaidPreview
+      .mockRejectedValueOnce(new Error('Parse error on line 2'))
+      .mockResolvedValueOnce('<svg>compat</svg>')
+
+    const result = await renderMermaidPreviewWithFallback({
+      ...baseOptions,
+      diagramCode: 'graph TD\n  A-->B',
+      isDark: true,
+      previewThemeOptions: { bg: '#000', fg: '#fff' },
+    })
+
+    expect(result).toEqual({
+      svg: '<svg>compat</svg>',
+      primaryError: 'Parse error on line 2',
+    })
+    expect(renderBeautifulMermaid).not.toHaveBeenCalled()
+  })
+
+  it('rethrows the primary official error when every fallback fails', async () => {
+    const primary = new Error('Primary official failure')
+    renderOfficialMermaidPreview.mockRejectedValue(primary)
+    renderBeautifulMermaid.mockRejectedValue(new Error('Legacy renderer failed'))
+
+    await expect(
+      renderMermaidPreviewWithFallback({
+        ...baseOptions,
+        diagramCode: 'classDiagram\nclass A',
+      }),
+    ).rejects.toThrow('Primary official failure')
+  })
+
+  it('throws MermaidAboutKeywordFallback when normalized code is about-only', async () => {
+    normalizeMermaidForBeautifulMermaid.mockImplementation(() => 'mermaid')
+    renderOfficialMermaidPreview.mockRejectedValue(new Error('Parse error'))
+    isMermaidAboutKeywordOnly.mockReturnValue(true)
+
+    await expect(
+      renderMermaidPreviewWithFallback({
+        ...baseOptions,
+        diagramCode: 'graph TD\nA-->B',
+      }),
+    ).rejects.toBeInstanceOf(MermaidAboutKeywordFallback)
+    expect(renderBeautifulMermaid).not.toHaveBeenCalled()
+  })
+})

--- a/src/utils/renderMermaidPreviewWithFallback.test.ts
+++ b/src/utils/renderMermaidPreviewWithFallback.test.ts
@@ -71,7 +71,7 @@ describe('renderMermaidPreviewWithFallback', () => {
     expect(result.primaryError).toBe('Namespace and class share the same name')
   })
 
-  it('keeps primaryError when compat-normalized official render succeeds', async () => {
+  it('clears primaryError when compat-normalized official render succeeds', async () => {
     normalizeMermaidForBeautifulMermaid.mockImplementation(
       (code: string) => `${code}\n%% normalized`,
     )
@@ -88,7 +88,7 @@ describe('renderMermaidPreviewWithFallback', () => {
 
     expect(result).toEqual({
       svg: '<svg>compat</svg>',
-      primaryError: 'Parse error on line 2',
+      primaryError: null,
     })
     expect(renderBeautifulMermaid).not.toHaveBeenCalled()
   })

--- a/src/utils/renderMermaidPreviewWithFallback.ts
+++ b/src/utils/renderMermaidPreviewWithFallback.ts
@@ -63,7 +63,9 @@ export async function renderMermaidPreviewWithFallback(options: {
           previewThemeOptions,
           officialYamlConfig,
         )
-        return { svg, primaryError }
+        // Compat rewrite still uses official Mermaid. Do not treat it as a
+        // silent fallback that should keep the original error banner.
+        return { svg, primaryError: null }
       } catch {
         // Continue to about-panel / beautiful-mermaid fallbacks.
       }

--- a/src/utils/renderMermaidPreviewWithFallback.ts
+++ b/src/utils/renderMermaidPreviewWithFallback.ts
@@ -22,10 +22,6 @@ export class MermaidAboutKeywordFallback extends Error {
   }
 }
 
-function toErrorMessage(err: unknown, fallback = 'Invalid Mermaid syntax'): string {
-  return err instanceof Error ? err.message : fallback
-}
-
 /**
  * Renders with official Mermaid first, then compat normalization, then beautiful-mermaid.
  * Callers keep the SVG on success and should still surface `primaryError` when non-null
@@ -56,10 +52,11 @@ export async function renderMermaidPreviewWithFallback(options: {
     )
     return { svg, primaryError: null }
   } catch (primaryErr) {
-    const primaryError = toErrorMessage(primaryErr)
+    const primaryError =
+      primaryErr instanceof Error ? primaryErr.message : 'Invalid Mermaid syntax'
 
-    try {
-      if (normalizedForCompat !== diagramCode) {
+    if (normalizedForCompat !== diagramCode) {
+      try {
         const svg = await renderOfficialMermaidPreview(
           normalizedForCompat,
           isDark,
@@ -67,22 +64,24 @@ export async function renderMermaidPreviewWithFallback(options: {
           officialYamlConfig,
         )
         return { svg, primaryError }
-      }
-      throw primaryErr
-    } catch {
-      if (isMermaidAboutKeywordOnly(normalizedForCompat)) {
-        throw new MermaidAboutKeywordFallback()
-      }
-      const themeOptions = yamlConfig
-        ? mapMermaidConfigToThemeOptions(yamlConfig)
-        : previewThemeOptions
-      try {
-        const svg = await renderBeautifulMermaid(normalizedForCompat, themeOptions)
-        return { svg, primaryError }
       } catch {
-        // Prefer the original official Mermaid error when every path fails.
-        throw primaryErr instanceof Error ? primaryErr : new Error(primaryError)
+        // Continue to about-panel / beautiful-mermaid fallbacks.
       }
+    }
+
+    if (isMermaidAboutKeywordOnly(normalizedForCompat)) {
+      throw new MermaidAboutKeywordFallback()
+    }
+
+    const themeOptions = yamlConfig
+      ? mapMermaidConfigToThemeOptions(yamlConfig)
+      : previewThemeOptions
+    try {
+      const svg = await renderBeautifulMermaid(normalizedForCompat, themeOptions)
+      return { svg, primaryError }
+    } catch {
+      // Prefer the original official Mermaid error when every path fails.
+      throw primaryErr instanceof Error ? primaryErr : new Error(primaryError)
     }
   }
 }

--- a/src/utils/renderMermaidPreviewWithFallback.ts
+++ b/src/utils/renderMermaidPreviewWithFallback.ts
@@ -1,0 +1,88 @@
+import { renderMermaid as renderBeautifulMermaid } from 'beautiful-mermaid'
+import { isMermaidAboutKeywordOnly } from './mermalaidInfoText'
+import {
+  mapMermaidConfigToThemeOptions,
+  type BeautifulMermaidThemeOptions,
+  type MermaidYamlConfig,
+} from './mermaidYamlConfig'
+import { normalizeMermaidForBeautifulMermaid } from './normalizeMermaidForBeautifulMermaid'
+import { renderOfficialMermaidPreview } from './officialMermaidPreview'
+
+export type MermaidPreviewRenderResult = {
+  svg: string
+  /** Set when the primary official render failed and a fallback produced the SVG. */
+  primaryError: string | null
+}
+
+/** Thrown when the fallback path should show the built-in about panel instead of an SVG. */
+export class MermaidAboutKeywordFallback extends Error {
+  constructor() {
+    super('MERMAID_ABOUT_KEYWORD')
+    this.name = 'MermaidAboutKeywordFallback'
+  }
+}
+
+function toErrorMessage(err: unknown, fallback = 'Invalid Mermaid syntax'): string {
+  return err instanceof Error ? err.message : fallback
+}
+
+/**
+ * Renders with official Mermaid first, then compat normalization, then beautiful-mermaid.
+ * Callers keep the SVG on success and should still surface `primaryError` when non-null
+ * so definition errors are not silently hidden by a fallback render.
+ */
+export async function renderMermaidPreviewWithFallback(options: {
+  diagramCode: string
+  isDark: boolean
+  previewThemeOptions: BeautifulMermaidThemeOptions
+  officialYamlConfig: MermaidYamlConfig | undefined
+  yamlConfig: MermaidYamlConfig | undefined
+}): Promise<MermaidPreviewRenderResult> {
+  const {
+    diagramCode,
+    isDark,
+    previewThemeOptions,
+    officialYamlConfig,
+    yamlConfig,
+  } = options
+  const normalizedForCompat = normalizeMermaidForBeautifulMermaid(diagramCode)
+
+  try {
+    const svg = await renderOfficialMermaidPreview(
+      diagramCode,
+      isDark,
+      previewThemeOptions,
+      officialYamlConfig,
+    )
+    return { svg, primaryError: null }
+  } catch (primaryErr) {
+    const primaryError = toErrorMessage(primaryErr)
+
+    try {
+      if (normalizedForCompat !== diagramCode) {
+        const svg = await renderOfficialMermaidPreview(
+          normalizedForCompat,
+          isDark,
+          previewThemeOptions,
+          officialYamlConfig,
+        )
+        return { svg, primaryError }
+      }
+      throw primaryErr
+    } catch {
+      if (isMermaidAboutKeywordOnly(normalizedForCompat)) {
+        throw new MermaidAboutKeywordFallback()
+      }
+      const themeOptions = yamlConfig
+        ? mapMermaidConfigToThemeOptions(yamlConfig)
+        : previewThemeOptions
+      try {
+        const svg = await renderBeautifulMermaid(normalizedForCompat, themeOptions)
+        return { svg, primaryError }
+      } catch {
+        // Prefer the original official Mermaid error when every path fails.
+        throw primaryErr instanceof Error ? primaryErr : new Error(primaryError)
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Keep official Mermaid + compat + beautiful-mermaid fallbacks
- When a fallback still renders, surface the original official error in the editor banner and a toast
- Extract `renderMermaidPreviewWithFallback` with unit coverage for the primary-error cases

Fixes #100

## Test plan
- [x] `npm run test -- --run src/utils/renderMermaidPreviewWithFallback.test.ts`
- [x] `npx tsc --noEmit`
- [ ] Manual: classDiagram with same-named namespace/class should still preview via fallback and show the official error in the banner/toast

