### PR TITLE
Save and export with native/browser file pickers (#99)

### DIFF
--- a/e2e/editor-toolbar.spec.ts
+++ b/e2e/editor-toolbar.spec.ts
@@ -6,6 +6,11 @@ import { expect, test } from '@playwright/test'
  */
 test.describe('Editor toolbar (web)', () => {
   test.beforeEach(async ({ page }) => {
+    // File System Access save picker is not usable under Playwright. Force the
+    // anchor-download fallback so Save / Export still emit download events.
+    await page.addInitScript(() => {
+      Reflect.deleteProperty(window, 'showSaveFilePicker')
+    })
     await page.goto('/editor')
     await expect(page.locator('.preview-svg-host')).toBeVisible({ timeout: 30_000 })
   })

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -39,6 +39,15 @@
       ]
     },
     {
+      "identifier": "fs:allow-write-file",
+      "allow": [
+        { "path": "$HOME/**" },
+        { "path": "$DOCUMENT/**" },
+        { "path": "$DESKTOP/**" },
+        { "path": "$DOWNLOAD/**" }
+      ]
+    },
+    {
       "identifier": "fs:scope",
       "allow": [
         { "path": "$HOME/**" },

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -7,7 +7,7 @@ import {
   type MutableRefObject,
 } from 'react'
 import { isTauri } from '@tauri-apps/api/core'
-import { message, open, save } from '@tauri-apps/plugin-dialog'
+import { message, open } from '@tauri-apps/plugin-dialog'
 import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs'
 import html2canvas from 'html2canvas'
 import { renderMermaidAscii, renderMermaid } from 'beautiful-mermaid'
@@ -41,6 +41,7 @@ import type { BridgeStatus } from '../agentBridge/bridgeClient'
 import { rebuildNativeAppMenu } from '../nativeAppMenu'
 import { addRecentFile, recentFileLabel, removeRecentFile } from '../utils/recentFiles'
 import { copyPlainTextWhenReady, formatClipboardFailureMessage } from '../utils/copyToClipboard'
+import { saveBlob, type SaveFileAcceptType, type SaveFileFilter } from '../utils/saveFile'
 import {
   applyPrivateShareFullUrlToHistory,
   assertPrivateShareUrlFits,
@@ -86,9 +87,68 @@ function wait(ms: number): Promise<void> {
   })
 }
 
-const OPEN_FILTERS = [
-  { name: 'Mermaid / Text', extensions: ['mmd', 'txt', 'md', 'markdown'] as string[] },
+const OPEN_FILTERS: SaveFileFilter[] = [
+  { name: 'Mermaid / Text', extensions: ['mmd', 'txt', 'md', 'markdown'] },
 ]
+
+const MERMAID_ACCEPT_TYPES: SaveFileAcceptType[] = [
+  {
+    description: 'Mermaid / Text',
+    accept: {
+      'text/plain': ['.mmd', '.txt'],
+      'text/markdown': ['.md', '.markdown'],
+    },
+  },
+]
+
+const SVG_EXPORT = {
+  suggestedName: 'diagram.svg',
+  filters: [{ name: 'SVG', extensions: ['svg'] }] satisfies SaveFileFilter[],
+  acceptTypes: [
+    { description: 'SVG', accept: { 'image/svg+xml': ['.svg'] } },
+  ] satisfies SaveFileAcceptType[],
+}
+
+const PNG_EXPORT = {
+  suggestedName: 'diagram.png',
+  filters: [{ name: 'PNG', extensions: ['png'] }] satisfies SaveFileFilter[],
+  acceptTypes: [
+    { description: 'PNG', accept: { 'image/png': ['.png'] } },
+  ] satisfies SaveFileAcceptType[],
+}
+
+const ASCII_EXPORT = {
+  suggestedName: 'diagram.txt',
+  filters: [{ name: 'Text', extensions: ['txt'] }] satisfies SaveFileFilter[],
+  acceptTypes: [
+    { description: 'Text', accept: { 'text/plain': ['.txt'] } },
+  ] satisfies SaveFileAcceptType[],
+}
+
+const HTML_EXPORT = {
+  suggestedName: 'diagrams.html',
+  filters: [{ name: 'HTML', extensions: ['html'] }] satisfies SaveFileFilter[],
+  acceptTypes: [
+    { description: 'HTML', accept: { 'text/html': ['.html'] } },
+  ] satisfies SaveFileAcceptType[],
+}
+
+function toastForSaveResult(
+  result: Awaited<ReturnType<typeof saveBlob>>,
+  verb: string,
+): string | null {
+  switch (result.outcome) {
+    case 'cancelled':
+      return null
+    case 'saved':
+    case 'downloaded':
+      return `${verb} ${result.fileName}`
+    default: {
+      const _exhaustive: never = result
+      return _exhaustive
+    }
+  }
+}
 
 const LICENSE_INFO_TEXT = `Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
 
@@ -319,33 +379,28 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
       }
       return
     }
-    const blob = new Blob([code], { type: 'text/plain' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'diagram.mmd'
-    a.click()
-    URL.revokeObjectURL(url)
-    showToast('Saved diagram.mmd')
+    await handleSaveAs()
   }
 
   const handleSaveAs = async () => {
-    if (!isTauri()) {
-      await handleSave()
-      return
-    }
     try {
-      const path = await save({
-        filters: OPEN_FILTERS,
+      const result = await saveBlob(new Blob([code], { type: 'text/plain' }), {
+        suggestedName: 'diagram.mmd',
         defaultPath: documentPathRef.current ?? 'diagram.mmd',
+        filters: OPEN_FILTERS,
+        acceptTypes: MERMAID_ACCEPT_TYPES,
       })
-      if (!path) return
-      await writeTextFile(path, code)
-      onDocumentSaved?.(code)
-      setDocumentPath(path)
-      addRecentFile(path)
-      await rebuildNativeAppMenu()
-      showToast(`Saved ${recentFileLabel(path)}`)
+      if (result.outcome === 'cancelled') return
+      if (result.outcome === 'saved') {
+        onDocumentSaved?.(code)
+        if (result.path) {
+          setDocumentPath(result.path)
+          addRecentFile(result.path)
+          await rebuildNativeAppMenu()
+        }
+      }
+      const message = toastForSaveResult(result, 'Saved')
+      if (message) showToast(message)
     } catch (err) {
       console.error('Save As error:', err)
       showToast('Could not save file.', 'error')
@@ -354,7 +409,7 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
 
   const handleDuplicate = async () => {
     if (!isTauri()) {
-      await handleSave()
+      await handleSaveAs()
       return
     }
     const base = documentPathRef.current
@@ -363,17 +418,20 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
         ? base.replace(/(\.[^.]+)$/, '-copy$1')
         : 'diagram-copy.mmd'
     try {
-      const path = await save({
-        filters: OPEN_FILTERS,
+      const result = await saveBlob(new Blob([code], { type: 'text/plain' }), {
+        suggestedName: 'diagram-copy.mmd',
         defaultPath: suggested,
+        filters: OPEN_FILTERS,
+        acceptTypes: MERMAID_ACCEPT_TYPES,
       })
-      if (!path) return
-      await writeTextFile(path, code)
-      onDocumentSaved?.(code)
-      setDocumentPath(path)
-      addRecentFile(path)
-      await rebuildNativeAppMenu()
-      showToast(`Saved ${recentFileLabel(path)}`)
+      if (result.outcome === 'cancelled') return
+      if (result.outcome === 'saved' && result.path) {
+        onDocumentSaved?.(code)
+        setDocumentPath(result.path)
+        addRecentFile(result.path)
+        await rebuildNativeAppMenu()
+        showToast(`Saved ${recentFileLabel(result.path)}`)
+      }
     } catch (err) {
       console.error('Duplicate save error:', err)
       showToast('Could not save duplicate.', 'error')
@@ -444,15 +502,17 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
       return
     }
 
-    const svgCode = svgElement.outerHTML
-    const blob = new Blob([svgCode], { type: 'image/svg+xml' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'diagram.svg'
-    a.click()
-    URL.revokeObjectURL(url)
-    showToast('Exported diagram.svg')
+    try {
+      const result = await saveBlob(
+        new Blob([svgElement.outerHTML], { type: 'image/svg+xml' }),
+        SVG_EXPORT,
+      )
+      const message = toastForSaveResult(result, 'Exported')
+      if (message) showToast(message)
+    } catch (err) {
+      console.error('SVG export error:', err)
+      showToast('Failed to export SVG.', 'error')
+    }
   }
 
   const handleExportPNG = async () => {
@@ -473,22 +533,17 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
         allowTaint: false,
       } as any)
 
-      canvas.toBlob((blob) => {
-        if (!blob) {
-          showToast('Failed to generate PNG', 'error')
-          return
-        }
+      const blob = await new Promise<Blob | null>((resolve) => {
+        canvas.toBlob((b) => resolve(b), 'image/png')
+      })
+      if (!blob) {
+        showToast('Failed to generate PNG', 'error')
+        return
+      }
 
-        const url = URL.createObjectURL(blob)
-        const a = document.createElement('a')
-        a.href = url
-        a.download = 'diagram.png'
-        document.body.appendChild(a)
-        a.click()
-        document.body.removeChild(a)
-        URL.revokeObjectURL(url)
-        showToast('Exported diagram.png')
-      }, 'image/png')
+      const result = await saveBlob(blob, PNG_EXPORT)
+      const message = toastForSaveResult(result, 'Exported')
+      if (message) showToast(message)
     } catch (err) {
       console.error('PNG export error:', err)
       showToast('Failed to export PNG: ' + (err instanceof Error ? err.message : 'Unknown error'), 'error')
@@ -501,18 +556,20 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
       showToast('No diagram to export', 'error')
       return
     }
+    const exportText = async (text: string) => {
+      try {
+        const result = await saveBlob(new Blob([text], { type: 'text/plain' }), ASCII_EXPORT)
+        const message = toastForSaveResult(result, 'Exported')
+        if (message) showToast(message)
+      } catch (err) {
+        console.error('ASCII export error:', err)
+        showToast('Failed to export ASCII.', 'error')
+      }
+    }
     if (isMermaidAboutKeywordOnly(diagramCode)) {
       void (async () => {
         try {
-          const text = await buildMermalaidInfoText()
-          const blob = new Blob([text], { type: 'text/plain' })
-          const url = URL.createObjectURL(blob)
-          const a = document.createElement('a')
-          a.href = url
-          a.download = 'diagram.txt'
-          a.click()
-          URL.revokeObjectURL(url)
-          showToast('Exported diagram.txt')
+          await exportText(await buildMermalaidInfoText())
         } catch (err) {
           console.error('ASCII export error:', err)
           showToast('Failed to export Mermalaid info.', 'error')
@@ -524,14 +581,7 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
       const ascii = renderMermaidAscii(
         normalizeMermaidForBeautifulMermaid(diagramCode),
       )
-      const blob = new Blob([ascii], { type: 'text/plain' })
-      const url = URL.createObjectURL(blob)
-      const a = document.createElement('a')
-      a.href = url
-      a.download = 'diagram.txt'
-      a.click()
-      URL.revokeObjectURL(url)
-      showToast('Exported diagram.txt')
+      void exportText(ascii)
     } catch (err) {
       const msg = err instanceof Error ? err.message : 'Unknown error'
       console.error('ASCII export error:', err)
@@ -723,13 +773,14 @@ ${svgs.map((svg, i) => `<div class="diagram"><h2>Diagram ${i + 1}</h2>${svg}</di
 </body></html>`
 
     const blob = new Blob([html], { type: 'text/html' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'diagrams.html'
-    a.click()
-    URL.revokeObjectURL(url)
-    showToast(`Exported ${svgs.length} diagrams as HTML`)
+    try {
+      const result = await saveBlob(blob, HTML_EXPORT)
+      const message = toastForSaveResult(result, `Exported ${svgs.length} diagrams as`)
+      if (message) showToast(message)
+    } catch (err) {
+      console.error('Export All error:', err)
+      showToast('Failed to export diagrams.', 'error')
+    }
   }
 
   const handleAIFix = async () => {

--- a/src/components/Toolbar.tsx
+++ b/src/components/Toolbar.tsx
@@ -41,7 +41,7 @@ import type { BridgeStatus } from '../agentBridge/bridgeClient'
 import { rebuildNativeAppMenu } from '../nativeAppMenu'
 import { addRecentFile, recentFileLabel, removeRecentFile } from '../utils/recentFiles'
 import { copyPlainTextWhenReady, formatClipboardFailureMessage } from '../utils/copyToClipboard'
-import { saveBlob, type SaveFileAcceptType, type SaveFileFilter } from '../utils/saveFile'
+import { saveBlob, saveFileKind, toastMessageForSaveResult, type SaveFileAcceptType, type SaveFileFilter } from '../utils/saveFile'
 import {
   applyPrivateShareFullUrlToHistory,
   assertPrivateShareUrlFits,
@@ -101,54 +101,10 @@ const MERMAID_ACCEPT_TYPES: SaveFileAcceptType[] = [
   },
 ]
 
-const SVG_EXPORT = {
-  suggestedName: 'diagram.svg',
-  filters: [{ name: 'SVG', extensions: ['svg'] }] satisfies SaveFileFilter[],
-  acceptTypes: [
-    { description: 'SVG', accept: { 'image/svg+xml': ['.svg'] } },
-  ] satisfies SaveFileAcceptType[],
-}
-
-const PNG_EXPORT = {
-  suggestedName: 'diagram.png',
-  filters: [{ name: 'PNG', extensions: ['png'] }] satisfies SaveFileFilter[],
-  acceptTypes: [
-    { description: 'PNG', accept: { 'image/png': ['.png'] } },
-  ] satisfies SaveFileAcceptType[],
-}
-
-const ASCII_EXPORT = {
-  suggestedName: 'diagram.txt',
-  filters: [{ name: 'Text', extensions: ['txt'] }] satisfies SaveFileFilter[],
-  acceptTypes: [
-    { description: 'Text', accept: { 'text/plain': ['.txt'] } },
-  ] satisfies SaveFileAcceptType[],
-}
-
-const HTML_EXPORT = {
-  suggestedName: 'diagrams.html',
-  filters: [{ name: 'HTML', extensions: ['html'] }] satisfies SaveFileFilter[],
-  acceptTypes: [
-    { description: 'HTML', accept: { 'text/html': ['.html'] } },
-  ] satisfies SaveFileAcceptType[],
-}
-
-function toastForSaveResult(
-  result: Awaited<ReturnType<typeof saveBlob>>,
-  verb: string,
-): string | null {
-  switch (result.outcome) {
-    case 'cancelled':
-      return null
-    case 'saved':
-    case 'downloaded':
-      return `${verb} ${result.fileName}`
-    default: {
-      const _exhaustive: never = result
-      return _exhaustive
-    }
-  }
-}
+const SVG_EXPORT = saveFileKind('diagram.svg', 'SVG', 'svg', 'image/svg+xml')
+const PNG_EXPORT = saveFileKind('diagram.png', 'PNG', 'png', 'image/png')
+const ASCII_EXPORT = saveFileKind('diagram.txt', 'Text', 'txt', 'text/plain')
+const HTML_EXPORT = saveFileKind('diagrams.html', 'HTML', 'html', 'text/html')
 
 const LICENSE_INFO_TEXT = `Creative Commons Attribution-NonCommercial-ShareAlike 4.0 International (CC BY-NC-SA 4.0)
 
@@ -399,8 +355,8 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
           await rebuildNativeAppMenu()
         }
       }
-      const message = toastForSaveResult(result, 'Saved')
-      if (message) showToast(message)
+      const toastMsg = toastMessageForSaveResult(result, 'Saved')
+      if (toastMsg) showToast(toastMsg)
     } catch (err) {
       console.error('Save As error:', err)
       showToast('Could not save file.', 'error')
@@ -507,8 +463,8 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
         new Blob([svgElement.outerHTML], { type: 'image/svg+xml' }),
         SVG_EXPORT,
       )
-      const message = toastForSaveResult(result, 'Exported')
-      if (message) showToast(message)
+      const toastMsg = toastMessageForSaveResult(result, 'Exported')
+      if (toastMsg) showToast(toastMsg)
     } catch (err) {
       console.error('SVG export error:', err)
       showToast('Failed to export SVG.', 'error')
@@ -542,8 +498,8 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
       }
 
       const result = await saveBlob(blob, PNG_EXPORT)
-      const message = toastForSaveResult(result, 'Exported')
-      if (message) showToast(message)
+      const toastMsg = toastMessageForSaveResult(result, 'Exported')
+      if (toastMsg) showToast(toastMsg)
     } catch (err) {
       console.error('PNG export error:', err)
       showToast('Failed to export PNG: ' + (err instanceof Error ? err.message : 'Unknown error'), 'error')
@@ -559,22 +515,20 @@ const Toolbar = forwardRef<ToolbarRef, ToolbarProps>(({
     const exportText = async (text: string) => {
       try {
         const result = await saveBlob(new Blob([text], { type: 'text/plain' }), ASCII_EXPORT)
-        const message = toastForSaveResult(result, 'Exported')
-        if (message) showToast(message)
+        const toastMsg = toastMessageForSaveResult(result, 'Exported')
+        if (toastMsg) showToast(toastMsg)
       } catch (err) {
         console.error('ASCII export error:', err)
         showToast('Failed to export ASCII.', 'error')
       }
     }
     if (isMermaidAboutKeywordOnly(diagramCode)) {
-      void (async () => {
-        try {
-          await exportText(await buildMermalaidInfoText())
-        } catch (err) {
+      void buildMermalaidInfoText()
+        .then((text) => exportText(text))
+        .catch((err) => {
           console.error('ASCII export error:', err)
           showToast('Failed to export Mermalaid info.', 'error')
-        }
-      })()
+        })
       return
     }
     try {
@@ -775,8 +729,8 @@ ${svgs.map((svg, i) => `<div class="diagram"><h2>Diagram ${i + 1}</h2>${svg}</di
     const blob = new Blob([html], { type: 'text/html' })
     try {
       const result = await saveBlob(blob, HTML_EXPORT)
-      const message = toastForSaveResult(result, `Exported ${svgs.length} diagrams as`)
-      if (message) showToast(message)
+      const toastMsg = toastMessageForSaveResult(result, `Exported ${svgs.length} diagrams as`)
+      if (toastMsg) showToast(toastMsg)
     } catch (err) {
       console.error('Export All error:', err)
       showToast('Failed to export diagrams.', 'error')

--- a/src/utils/saveFile.test.ts
+++ b/src/utils/saveFile.test.ts
@@ -2,20 +2,38 @@ import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const isTauri = vi.hoisted(() => vi.fn(() => false))
 const saveDialog = vi.hoisted(() => vi.fn())
-const writeTextFile = vi.hoisted(() => vi.fn())
 const writeFile = vi.hoisted(() => vi.fn())
 
 vi.mock('@tauri-apps/api/core', () => ({ isTauri }))
 vi.mock('@tauri-apps/plugin-dialog', () => ({ save: saveDialog }))
-vi.mock('@tauri-apps/plugin-fs', () => ({ writeTextFile, writeFile }))
+vi.mock('@tauri-apps/plugin-fs', () => ({ writeFile }))
 
-import { downloadBlob, saveBlob } from './saveFile'
+import { downloadBlob, saveBlob, saveFileKind, toastMessageForSaveResult } from './saveFile'
 
 const TEXT_OPTIONS = {
   suggestedName: 'diagram.mmd',
   filters: [{ name: 'Mermaid', extensions: ['mmd'] }],
   acceptTypes: [{ description: 'Mermaid', accept: { 'text/plain': ['.mmd'] } }],
 }
+
+describe('saveFileKind', () => {
+  it('builds filter and accept metadata for one extension', () => {
+    expect(saveFileKind('diagram.svg', 'SVG', 'svg', 'image/svg+xml')).toEqual({
+      suggestedName: 'diagram.svg',
+      filters: [{ name: 'SVG', extensions: ['svg'] }],
+      acceptTypes: [{ description: 'SVG', accept: { 'image/svg+xml': ['.svg'] } }],
+    })
+  })
+})
+
+describe('toastMessageForSaveResult', () => {
+  it('returns null for cancel and a verb+name otherwise', () => {
+    expect(toastMessageForSaveResult({ outcome: 'cancelled' }, 'Saved')).toBeNull()
+    expect(
+      toastMessageForSaveResult({ outcome: 'downloaded', fileName: 'diagram.mmd' }, 'Saved'),
+    ).toBe('Saved diagram.mmd')
+  })
+})
 
 describe('downloadBlob', () => {
   it('creates an anchor download and revokes the object URL', () => {
@@ -49,14 +67,13 @@ describe('saveBlob', () => {
   beforeEach(() => {
     isTauri.mockReturnValue(false)
     saveDialog.mockReset()
-    writeTextFile.mockReset()
     writeFile.mockReset()
   })
 
-  it('uses the Tauri save dialog and writeTextFile for text blobs', async () => {
+  it('uses the Tauri save dialog and writeFile', async () => {
     isTauri.mockReturnValue(true)
     saveDialog.mockResolvedValue('/Users/me/docs/flow.mmd')
-    writeTextFile.mockResolvedValue(undefined)
+    writeFile.mockResolvedValue(undefined)
 
     const result = await saveBlob(new Blob(['graph TD'], { type: 'text/plain' }), TEXT_OPTIONS)
 
@@ -64,29 +81,14 @@ describe('saveBlob', () => {
       filters: TEXT_OPTIONS.filters,
       defaultPath: 'diagram.mmd',
     })
-    expect(writeTextFile).toHaveBeenCalledWith('/Users/me/docs/flow.mmd', 'graph TD')
+    expect(writeFile).toHaveBeenCalled()
+    const [, bytes] = writeFile.mock.calls[0]
+    expect(new TextDecoder().decode(bytes)).toBe('graph TD')
     expect(result).toEqual({
       outcome: 'saved',
       path: '/Users/me/docs/flow.mmd',
       fileName: 'flow.mmd',
     })
-  })
-
-  it('uses writeFile for binary blobs on Tauri', async () => {
-    isTauri.mockReturnValue(true)
-    saveDialog.mockResolvedValue('/tmp/diagram.png')
-    writeFile.mockResolvedValue(undefined)
-    const bytes = new Uint8Array([1, 2, 3])
-
-    const result = await saveBlob(new Blob([bytes], { type: 'image/png' }), {
-      suggestedName: 'diagram.png',
-      filters: [{ name: 'PNG', extensions: ['png'] }],
-      acceptTypes: [{ description: 'PNG', accept: { 'image/png': ['.png'] } }],
-    })
-
-    expect(writeFile).toHaveBeenCalled()
-    expect(writeTextFile).not.toHaveBeenCalled()
-    expect(result.outcome).toBe('saved')
   })
 
   it('returns cancelled when the Tauri dialog is dismissed', async () => {
@@ -95,7 +97,7 @@ describe('saveBlob', () => {
 
     const result = await saveBlob(new Blob(['x'], { type: 'text/plain' }), TEXT_OPTIONS)
     expect(result).toEqual({ outcome: 'cancelled' })
-    expect(writeTextFile).not.toHaveBeenCalled()
+    expect(writeFile).not.toHaveBeenCalled()
   })
 
   it('uses showSaveFilePicker when available on the web', async () => {

--- a/src/utils/saveFile.test.ts
+++ b/src/utils/saveFile.test.ts
@@ -135,6 +135,55 @@ describe('saveBlob', () => {
     }
   })
 
+  it.each([
+    ['SecurityError', 'Must be handling a user gesture'],
+    ['NotAllowedError', 'Permission denied'],
+  ] as const)(
+    'falls back to anchor download when showSaveFilePicker throws %s',
+    async (errorName, message) => {
+      const click = vi.fn()
+      vi.stubGlobal(
+        'showSaveFilePicker',
+        vi.fn().mockRejectedValue(new DOMException(message, errorName)),
+      )
+      vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node)
+      vi.spyOn(document.body, 'removeChild').mockImplementation((node) => node)
+      vi.stubGlobal('URL', {
+        createObjectURL: vi.fn(() => 'blob:x'),
+        revokeObjectURL: vi.fn(),
+      })
+      vi.spyOn(document, 'createElement').mockReturnValue({
+        href: '',
+        download: '',
+        click,
+      } as unknown as HTMLAnchorElement)
+
+      try {
+        const result = await saveBlob(new Blob(['code'], { type: 'text/plain' }), TEXT_OPTIONS)
+        expect(click).toHaveBeenCalled()
+        expect(result).toEqual({ outcome: 'downloaded', fileName: 'diagram.mmd' })
+      } finally {
+        vi.restoreAllMocks()
+        vi.unstubAllGlobals()
+      }
+    },
+  )
+
+  it('rethrows unexpected picker errors', async () => {
+    vi.stubGlobal(
+      'showSaveFilePicker',
+      vi.fn().mockRejectedValue(new DOMException('disk full', 'QuotaExceededError')),
+    )
+
+    try {
+      await expect(
+        saveBlob(new Blob(['code'], { type: 'text/plain' }), TEXT_OPTIONS),
+      ).rejects.toMatchObject({ name: 'QuotaExceededError' })
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
   it('falls back to anchor download when no picker is available', async () => {
     const click = vi.fn()
     vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node)

--- a/src/utils/saveFile.test.ts
+++ b/src/utils/saveFile.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const isTauri = vi.hoisted(() => vi.fn(() => false))
+const saveDialog = vi.hoisted(() => vi.fn())
+const writeTextFile = vi.hoisted(() => vi.fn())
+const writeFile = vi.hoisted(() => vi.fn())
+
+vi.mock('@tauri-apps/api/core', () => ({ isTauri }))
+vi.mock('@tauri-apps/plugin-dialog', () => ({ save: saveDialog }))
+vi.mock('@tauri-apps/plugin-fs', () => ({ writeTextFile, writeFile }))
+
+import { downloadBlob, saveBlob } from './saveFile'
+
+const TEXT_OPTIONS = {
+  suggestedName: 'diagram.mmd',
+  filters: [{ name: 'Mermaid', extensions: ['mmd'] }],
+  acceptTypes: [{ description: 'Mermaid', accept: { 'text/plain': ['.mmd'] } }],
+}
+
+describe('downloadBlob', () => {
+  it('creates an anchor download and revokes the object URL', () => {
+    const click = vi.fn()
+    const appendChild = vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node)
+    const removeChild = vi.spyOn(document.body, 'removeChild').mockImplementation((node) => node)
+    const createObjectURL = vi.fn(() => 'blob:mock')
+    const revokeObjectURL = vi.fn()
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
+    const createElement = vi.spyOn(document, 'createElement').mockReturnValue({
+      href: '',
+      download: '',
+      click,
+    } as unknown as HTMLAnchorElement)
+
+    try {
+      downloadBlob(new Blob(['hi'], { type: 'text/plain' }), 'diagram.mmd')
+      expect(createObjectURL).toHaveBeenCalled()
+      expect(click).toHaveBeenCalled()
+      expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock')
+    } finally {
+      createElement.mockRestore()
+      appendChild.mockRestore()
+      removeChild.mockRestore()
+      vi.unstubAllGlobals()
+    }
+  })
+})
+
+describe('saveBlob', () => {
+  beforeEach(() => {
+    isTauri.mockReturnValue(false)
+    saveDialog.mockReset()
+    writeTextFile.mockReset()
+    writeFile.mockReset()
+  })
+
+  it('uses the Tauri save dialog and writeTextFile for text blobs', async () => {
+    isTauri.mockReturnValue(true)
+    saveDialog.mockResolvedValue('/Users/me/docs/flow.mmd')
+    writeTextFile.mockResolvedValue(undefined)
+
+    const result = await saveBlob(new Blob(['graph TD'], { type: 'text/plain' }), TEXT_OPTIONS)
+
+    expect(saveDialog).toHaveBeenCalledWith({
+      filters: TEXT_OPTIONS.filters,
+      defaultPath: 'diagram.mmd',
+    })
+    expect(writeTextFile).toHaveBeenCalledWith('/Users/me/docs/flow.mmd', 'graph TD')
+    expect(result).toEqual({
+      outcome: 'saved',
+      path: '/Users/me/docs/flow.mmd',
+      fileName: 'flow.mmd',
+    })
+  })
+
+  it('uses writeFile for binary blobs on Tauri', async () => {
+    isTauri.mockReturnValue(true)
+    saveDialog.mockResolvedValue('/tmp/diagram.png')
+    writeFile.mockResolvedValue(undefined)
+    const bytes = new Uint8Array([1, 2, 3])
+
+    const result = await saveBlob(new Blob([bytes], { type: 'image/png' }), {
+      suggestedName: 'diagram.png',
+      filters: [{ name: 'PNG', extensions: ['png'] }],
+      acceptTypes: [{ description: 'PNG', accept: { 'image/png': ['.png'] } }],
+    })
+
+    expect(writeFile).toHaveBeenCalled()
+    expect(writeTextFile).not.toHaveBeenCalled()
+    expect(result.outcome).toBe('saved')
+  })
+
+  it('returns cancelled when the Tauri dialog is dismissed', async () => {
+    isTauri.mockReturnValue(true)
+    saveDialog.mockResolvedValue(null)
+
+    const result = await saveBlob(new Blob(['x'], { type: 'text/plain' }), TEXT_OPTIONS)
+    expect(result).toEqual({ outcome: 'cancelled' })
+    expect(writeTextFile).not.toHaveBeenCalled()
+  })
+
+  it('uses showSaveFilePicker when available on the web', async () => {
+    const write = vi.fn().mockResolvedValue(undefined)
+    const close = vi.fn().mockResolvedValue(undefined)
+    const showSaveFilePicker = vi.fn().mockResolvedValue({
+      name: 'chosen.mmd',
+      createWritable: async () => ({ write, close }),
+    })
+    vi.stubGlobal('showSaveFilePicker', showSaveFilePicker)
+
+    try {
+      const blob = new Blob(['code'], { type: 'text/plain' })
+      const result = await saveBlob(blob, TEXT_OPTIONS)
+      expect(showSaveFilePicker).toHaveBeenCalled()
+      expect(write).toHaveBeenCalledWith(blob)
+      expect(close).toHaveBeenCalled()
+      expect(result).toEqual({ outcome: 'saved', fileName: 'chosen.mmd' })
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('returns cancelled when the web picker is aborted', async () => {
+    vi.stubGlobal(
+      'showSaveFilePicker',
+      vi.fn().mockRejectedValue(new DOMException('user cancel', 'AbortError')),
+    )
+
+    try {
+      const result = await saveBlob(new Blob(['code'], { type: 'text/plain' }), TEXT_OPTIONS)
+      expect(result).toEqual({ outcome: 'cancelled' })
+    } finally {
+      vi.unstubAllGlobals()
+    }
+  })
+
+  it('falls back to anchor download when no picker is available', async () => {
+    const click = vi.fn()
+    vi.spyOn(document.body, 'appendChild').mockImplementation((node) => node)
+    vi.spyOn(document.body, 'removeChild').mockImplementation((node) => node)
+    vi.stubGlobal('URL', {
+      createObjectURL: vi.fn(() => 'blob:x'),
+      revokeObjectURL: vi.fn(),
+    })
+    vi.spyOn(document, 'createElement').mockReturnValue({
+      href: '',
+      download: '',
+      click,
+    } as unknown as HTMLAnchorElement)
+
+    try {
+      const result = await saveBlob(new Blob(['code'], { type: 'text/plain' }), TEXT_OPTIONS)
+      expect(click).toHaveBeenCalled()
+      expect(result).toEqual({ outcome: 'downloaded', fileName: 'diagram.mmd' })
+    } finally {
+      vi.restoreAllMocks()
+      vi.unstubAllGlobals()
+    }
+  })
+})

--- a/src/utils/saveFile.ts
+++ b/src/utils/saveFile.ts
@@ -59,6 +59,22 @@ function isAbortError(err: unknown): boolean {
   return err instanceof DOMException && err.name === 'AbortError'
 }
 
+/**
+ * Picker failures where falling back to an anchor download is appropriate.
+ * Chromium throws SecurityError / NotAllowedError when transient user activation
+ * is gone (e.g. after awaiting html2canvas or other async work before the picker).
+ */
+function isSavePickerFallbackError(err: unknown): boolean {
+  if (!(err instanceof DOMException)) return false
+  switch (err.name) {
+    case 'SecurityError':
+    case 'NotAllowedError':
+      return true
+    default:
+      return false
+  }
+}
+
 /** Build SaveFileOptions for a single extension / MIME pair. */
 export function saveFileKind(
   suggestedName: string,
@@ -144,7 +160,8 @@ export async function saveBlob(blob: Blob, options: SaveFileOptions): Promise<Sa
       return { outcome: 'saved', fileName: handle.name || suggestedName }
     } catch (err) {
       if (isAbortError(err)) return { outcome: 'cancelled' }
-      throw err
+      if (!isSavePickerFallbackError(err)) throw err
+      // Fall through to anchor download when activation/security blocks the picker.
     }
   }
 

--- a/src/utils/saveFile.ts
+++ b/src/utils/saveFile.ts
@@ -5,7 +5,8 @@
 
 import { isTauri } from '@tauri-apps/api/core'
 import { save } from '@tauri-apps/plugin-dialog'
-import { writeFile, writeTextFile } from '@tauri-apps/plugin-fs'
+import { writeFile } from '@tauri-apps/plugin-fs'
+import { recentFileLabel } from './recentFiles'
 
 export type SaveFileFilter = {
   name: string
@@ -58,10 +59,35 @@ function isAbortError(err: unknown): boolean {
   return err instanceof DOMException && err.name === 'AbortError'
 }
 
-function fileNameFromPath(path: string): string {
-  const normalized = path.replace(/\\/g, '/')
-  const parts = normalized.split('/')
-  return parts[parts.length - 1] || path
+/** Build SaveFileOptions for a single extension / MIME pair. */
+export function saveFileKind(
+  suggestedName: string,
+  filterName: string,
+  extension: string,
+  mimeType: string,
+): SaveFileOptions {
+  return {
+    suggestedName,
+    filters: [{ name: filterName, extensions: [extension] }],
+    acceptTypes: [
+      { description: filterName, accept: { [mimeType]: [`.${extension}`] } },
+    ],
+  }
+}
+
+/** User-facing toast body, or null when the user cancelled. */
+export function toastMessageForSaveResult(result: SaveFileResult, verb: string): string | null {
+  switch (result.outcome) {
+    case 'cancelled':
+      return null
+    case 'saved':
+    case 'downloaded':
+      return `${verb} ${result.fileName}`
+    default: {
+      const _exhaustive: never = result
+      return _exhaustive
+    }
+  }
 }
 
 /** Trigger a browser download with the given filename (no picker). */
@@ -88,17 +114,6 @@ function readBlobAsArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
   })
 }
 
-async function writeBlobToTauriPath(path: string, blob: Blob): Promise<void> {
-  const buffer = await readBlobAsArrayBuffer(blob)
-  const isText =
-    blob.type.startsWith('text/') || blob.type === 'image/svg+xml' || blob.type === ''
-  if (isText) {
-    await writeTextFile(path, new TextDecoder().decode(buffer))
-    return
-  }
-  await writeFile(path, new Uint8Array(buffer))
-}
-
 /**
  * Prompt the user to save `blob` (or download it when no picker is available).
  * Cancellation returns `{ outcome: 'cancelled' }` without throwing.
@@ -112,8 +127,8 @@ export async function saveBlob(blob: Blob, options: SaveFileOptions): Promise<Sa
       defaultPath: options.defaultPath ?? suggestedName,
     })
     if (!path) return { outcome: 'cancelled' }
-    await writeBlobToTauriPath(path, blob)
-    return { outcome: 'saved', path, fileName: fileNameFromPath(path) }
+    await writeFile(path, new Uint8Array(await readBlobAsArrayBuffer(blob)))
+    return { outcome: 'saved', path, fileName: recentFileLabel(path) }
   }
 
   const showSaveFilePicker = getShowSaveFilePicker()

--- a/src/utils/saveFile.ts
+++ b/src/utils/saveFile.ts
@@ -1,0 +1,138 @@
+/**
+ * Save a Blob via native dialog (Tauri), File System Access API (supported browsers),
+ * or an anchor download fallback.
+ */
+
+import { isTauri } from '@tauri-apps/api/core'
+import { save } from '@tauri-apps/plugin-dialog'
+import { writeFile, writeTextFile } from '@tauri-apps/plugin-fs'
+
+export type SaveFileFilter = {
+  name: string
+  extensions: string[]
+}
+
+export type SaveFileAcceptType = {
+  description: string
+  accept: Record<string, string[]>
+}
+
+export type SaveFileOptions = {
+  suggestedName: string
+  /** Tauri dialog default path (may be a full path when re-saving). */
+  defaultPath?: string
+  filters: SaveFileFilter[]
+  acceptTypes: SaveFileAcceptType[]
+}
+
+export type SaveFileResult =
+  | { outcome: 'saved'; fileName: string; path?: string }
+  | { outcome: 'cancelled' }
+  | { outcome: 'downloaded'; fileName: string }
+
+type SaveFilePickerOptions = {
+  suggestedName?: string
+  types?: SaveFileAcceptType[]
+}
+
+type FileSystemWritableFileStreamLike = {
+  write(data: Blob | BufferSource | string): Promise<void>
+  close(): Promise<void>
+}
+
+type FileSystemFileHandleLike = {
+  name: string
+  createWritable(): Promise<FileSystemWritableFileStreamLike>
+}
+
+function getShowSaveFilePicker():
+  | ((options?: SaveFilePickerOptions) => Promise<FileSystemFileHandleLike>)
+  | undefined {
+  const w = window as Window & {
+    showSaveFilePicker?: (options?: SaveFilePickerOptions) => Promise<FileSystemFileHandleLike>
+  }
+  return typeof w.showSaveFilePicker === 'function' ? w.showSaveFilePicker.bind(w) : undefined
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === 'AbortError'
+}
+
+function fileNameFromPath(path: string): string {
+  const normalized = path.replace(/\\/g, '/')
+  const parts = normalized.split('/')
+  return parts[parts.length - 1] || path
+}
+
+/** Trigger a browser download with the given filename (no picker). */
+export function downloadBlob(blob: Blob, fileName: string): void {
+  const url = URL.createObjectURL(blob)
+  const a = document.createElement('a')
+  a.href = url
+  a.download = fileName
+  document.body.appendChild(a)
+  a.click()
+  document.body.removeChild(a)
+  URL.revokeObjectURL(url)
+}
+
+function readBlobAsArrayBuffer(blob: Blob): Promise<ArrayBuffer> {
+  if (typeof blob.arrayBuffer === 'function') {
+    return blob.arrayBuffer()
+  }
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as ArrayBuffer)
+    reader.onerror = () => reject(reader.error ?? new Error('Failed to read file data'))
+    reader.readAsArrayBuffer(blob)
+  })
+}
+
+async function writeBlobToTauriPath(path: string, blob: Blob): Promise<void> {
+  const buffer = await readBlobAsArrayBuffer(blob)
+  const isText =
+    blob.type.startsWith('text/') || blob.type === 'image/svg+xml' || blob.type === ''
+  if (isText) {
+    await writeTextFile(path, new TextDecoder().decode(buffer))
+    return
+  }
+  await writeFile(path, new Uint8Array(buffer))
+}
+
+/**
+ * Prompt the user to save `blob` (or download it when no picker is available).
+ * Cancellation returns `{ outcome: 'cancelled' }` without throwing.
+ */
+export async function saveBlob(blob: Blob, options: SaveFileOptions): Promise<SaveFileResult> {
+  const suggestedName = options.suggestedName
+
+  if (isTauri()) {
+    const path = await save({
+      filters: options.filters,
+      defaultPath: options.defaultPath ?? suggestedName,
+    })
+    if (!path) return { outcome: 'cancelled' }
+    await writeBlobToTauriPath(path, blob)
+    return { outcome: 'saved', path, fileName: fileNameFromPath(path) }
+  }
+
+  const showSaveFilePicker = getShowSaveFilePicker()
+  if (showSaveFilePicker) {
+    try {
+      const handle = await showSaveFilePicker({
+        suggestedName,
+        types: options.acceptTypes,
+      })
+      const writable = await handle.createWritable()
+      await writable.write(blob)
+      await writable.close()
+      return { outcome: 'saved', fileName: handle.name || suggestedName }
+    } catch (err) {
+      if (isAbortError(err)) return { outcome: 'cancelled' }
+      throw err
+    }
+  }
+
+  downloadBlob(blob, suggestedName)
+  return { outcome: 'downloaded', fileName: suggestedName }
+}


### PR DESCRIPTION
- Shared save helper for Tauri native dialogs and web `showSaveFilePicker` (with download fallback)
- Toolbar Save with no open file goes through Save As
- Export SVG / PNG / ASCII / Export All use the same picker path
- No new Save As toolbar button (File menu remains enough)

Fixes #99

## Test plan
- [x] Unit tests for the save helper
- [x] Related App / recent-files tests
- [x] `tsc --noEmit`
- [x] Manual Tauri: Save with no path opens native Save As, exports open native save dialogs
- [x] Manual web: picker where supported, download fallback otherwise
