### PR TITLE
Release v1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mermalaid",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mermalaid",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "CC-BY-NC-SA-4.0",
       "dependencies": {
         "@dagrejs/dagre": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mermalaid",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "type": "module",
   "license": "CC-BY-NC-SA-4.0",
   "engines": {

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mermalaid"
-version = "1.7.0"
+version = "1.7.1"
 description = "Mermalaid - A native macOS Mermaid diagram editor"
 authors = ["Dario Novoa Vergara"]
 license = "CC-BY-NC-SA-4.0"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Mermalaid",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "identifier": "com.mermalaid.desktop",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
- Bump app version to 1.7.1 in package.json, package-lock.json, src-tauri/Cargo.toml, and src-tauri/tauri.conf.json
- Desktop release tag v1.7.1 will be pushed after this merges to trigger the Tauri workflow

## Test plan
- [x] Version files show 1.7.1 on this branch
- [x] Merge, then tag v1.7.1 and confirm Release workflow runs
